### PR TITLE
Check connection before moving on

### DIFF
--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -25,7 +25,7 @@ type
     pubCallbacks: seq[PubCallback]
 
   State = enum
-    Disabled, Disconnected, Connecting, Connected, Disconnecting
+    Disabled, Disconnected, Connecting, Connected, Disconnecting, Error
 
   MsgId = uint16
 
@@ -413,13 +413,14 @@ proc runConnect(ctx: MqttCtx) {.async.} =
           else:
             ctx.wrn "requested SSL session but ssl is not enabled"
             await ctx.close
-            return
+            ctx.state = Error
         let ok = await ctx.sendConnect()
         if ok:
           asyncCheck ctx.runRx()
           asyncCheck ctx.runPing()
       except OSError as e:
         ctx.dbg "Error connecting to " & ctx.host & " " & e.msg
+        ctx.state = Error
 
     await sleepAsync 1000
 
@@ -442,7 +443,7 @@ proc set_auth*(ctx: MqttCtx, username: string, password: string) =
 proc start*(ctx: MqttCtx) {.async.} =
   ctx.state = Disconnected
   asyncCheck ctx.runConnect()
-  while ctx.state != Connected:
+  while ctx.state != Connected and ctx.state != Error:
     await sleepAsync 1000
 
 proc publish*(ctx: MqttCtx, topic: string, message: string, qos=0) {.async.} =

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -137,7 +137,7 @@ proc newPkt(typ: PktType=NOTYPE, flags: uint8=0): Pkt =
 #
 
 proc dmp(ctx: MqttCtx, s: string) =
-  if true:
+  when defined(dev):
     stderr.write "\e[1;30m" & s & "\e[0m\n"
 
 proc dbg(ctx: MqttCtx, s: string) =

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -4,7 +4,6 @@
 import strutils
 import asyncnet
 import net
-import os
 import asyncDispatch
 import tables
 

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -442,6 +442,8 @@ proc set_auth*(ctx: MqttCtx, username: string, password: string) =
 proc start*(ctx: MqttCtx) {.async.} =
   ctx.state = Disconnected
   asyncCheck ctx.runConnect()
+  while ctx.state != Connected:
+    await sleepAsync 1000
 
 proc publish*(ctx: MqttCtx, topic: string, message: string, qos=0) {.async.} =
   let msgId = ctx.nextMsgId()


### PR DESCRIPTION

____

1) Remove unused import of `os`
____

2) Only print `tx` and `rx` when using dev-mode
____

3) Implement connection check before moving on from `ctx.start()`.

`await ctx.start()` does not await until the connection is established. The user needs to insert a custom sleepAsync, but the sleeptime is only a guess. Therefor I have added a connection check inside `start*()` based on the state.
The logic in `proc start*()` could be moved out of the proc, but then the user should be aware of it and implement it themself. Up to you.