### PR TITLE
Await message is published

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
+## Native Nim MQTT client library, work in progress
 
-Native Nim MQTT client library, work in progress
+## Examples
 
-Usage:
-
-
-```
-
+```nim
 import nmqtt, asyncdispatch
 
 let ctx = newMqttCtx("hallo")
@@ -15,12 +12,83 @@ ctx.set_host("test.mosquitto.org", 1883)
 
 await ctx.start()
 proc on_data(topic: string, message: string) =
-  echo "got ", topic, ": ", message
+echo "got ", topic, ": ", message
 
 await ctx.publish("test1", "hallo", 2)
 await ctx.subscribe("#", 0, on_data)
 
 asyncCheck flop()
 runForever()
-
 ```
+
+
+# Procs
+
+## newMqttCtx*
+
+```nim
+proc newMqttCtx*(clientId: string): MqttCtx =
+```
+
+Initiate a new MQTT client
+
+
+____
+
+## set_host*
+
+```nim
+proc set_host*(ctx: MqttCtx, host: string, port: int=1883, doSsl=false) =
+```
+
+Set the MQTT host
+
+
+____
+
+## set_auth*
+
+```nim
+proc set_auth*(ctx: MqttCtx, username: string, password: string) =
+```
+
+Set the authentication for the host
+
+
+____
+
+## start*
+
+```nim
+proc start*(ctx: MqttCtx) {.async.} =
+```
+
+Connect to the host.
+
+ You might want to insert a `await sleepAsync 3000`, to let the first pings through before sending.
+
+
+____
+
+## publish*
+
+```nim
+proc publish*(ctx: MqttCtx, topic: string, message: string, qos=0) {.async.} =
+```
+
+Publish a message
+
+
+____
+
+## subscribe*
+
+```nim
+proc subscribe*(ctx: MqttCtx, topic: string, qos: int, callback: PubCallback) {.async.} =
+```
+
+Subscribe to a topic
+
+
+____
+

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -358,7 +358,8 @@ proc onPubRec(ctx: MqttCtx, pkt: Pkt) {.async.} =
   assert ctx.workQueue[msgId].qos == 2
   var pkt = newPkt(PubRel, 0b0010)
   pkt.put(msgId)
-  discard await ctx.send(pkt)
+  if await ctx.send(pkt):
+    discard
 
 proc onPubComp(ctx: MqttCtx, pkt: Pkt) {.async.} =
   let (msgId, _) = pkt.getu16(0)

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -1,3 +1,27 @@
+## Native Nim MQTT client library, work in progress
+## ---------------
+##
+## Examples
+## --------
+##
+## .. code-block::plain
+##    import nmqtt, asyncdispatch
+##
+##    let ctx = newMqttCtx("hallo")
+##
+##    ctx.set_host("test.mosquitto.org", 1883)
+##    #ctx.set_auth("username", "password")
+##
+##    await ctx.start()
+##    proc on_data(topic: string, message: string) =
+##      echo "got ", topic, ": ", message
+##
+##    await ctx.publish("test1", "hallo", 2)
+##    await ctx.subscribe("#", 0, on_data)
+##
+##    asyncCheck flop()
+##    runForever()
+##
 
 #{.experimental: "codeReordering".}
 
@@ -428,29 +452,44 @@ proc runConnect(ctx: MqttCtx) {.async.} =
 #
 
 proc newMqttCtx*(clientId: string): MqttCtx =
+  ## Initiate a new MQTT client
+
   MqttCtx(clientId: clientId)
 
 proc set_host*(ctx: MqttCtx, host: string, port: int=1883, doSsl=false) =
+  ## Set the MQTT host
+
   ctx.host = host
   ctx.port = Port(port)
   ctx.doSsl = doSsl
 
 proc set_auth*(ctx: MqttCtx, username: string, password: string) =
+  ## Set the authentication for the host
+
   ctx.username = username
   ctx.password = password
 
 proc start*(ctx: MqttCtx) {.async.} =
+  ## Connect to the host.
+  ##
+  ## You might want to insert a `await sleepAsync 3000`, to let the first pings
+  ## through before sending.
+
   ctx.state = Disconnected
   asyncCheck ctx.runConnect()
   while ctx.state != Connected and ctx.state != Error:
     await sleepAsync 1000
 
 proc publish*(ctx: MqttCtx, topic: string, message: string, qos=0) {.async.} =
+  ## Publish a message
+
   let msgId = ctx.nextMsgId()
   ctx.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, topic: topic, message: message, qos: qos)
   await ctx.work()
 
 proc subscribe*(ctx: MqttCtx, topic: string, qos: int, callback: PubCallback) {.async.} =
+  ## Subscribe to a topic
+
   let msgId = ctx.nextMsgId()
   ctx.workQueue[msgId] = Work(wk: SubWork, msgId: msgId, topic: topic, qos: qos)
   ctx.pubCallbacks.add callback

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -307,7 +307,7 @@ proc work(ctx: MqttCtx, connEstablished = false) {.async.} =
             work.state = WorkSent
     
       if connEstablished:
-        # Error: Queue contains a qos=1 message. Possible due to break in conn.
+        # Error: Queue contains a message. Possible due to break in conn.
         if work.state == WorkSent:
           ctx.dbg "Error a msg died in the queue"
           delWork.add msgId


### PR DESCRIPTION
Hi @zevv 

This PR has some changes to the logic of the message flow. Please let me know, if this is to much or if you would like some changes to it.

_____

This PR has 2 purposes:
* Await the `publish()` until the message is sent. Currently the user needs to use `sleepAsync` and guess the waiting time.
* Handle messages in the queue, when the connection breaks

## Await publish
The feature for "real" waiting is done within the `publish` proc when `waitConfirmation=true`. The loop will check, that the msgId is still present in the workQueue. This requires, that a message sent with `qos=2` is first removed from the queue in `onPubComp` instead of `onPubRec` (4-way).

_(It respects the current structure, but I would advise, that `waitConfirmation=true` should be standard)_

The user can now call this:
```nim
proc doMsg() {.async.} =
  await ctx.start()
  await ctx.publish("topic", "msg", 0, true)

waitFor doMsg()
```

If user does not wants to wait, the `waitConfirmation` can be left out. That requires a `sleepAsync`:
```nim
proc doMsg() {.async.} =
  await ctx.start()
  await ctx.publish("topic", "msg", 0)
  await sleepAsync 2000

waitFor doMsg()
```

## Break in connection
I have had some breaks in the connection with mosquitto, but I cant figure out why: 
```
Mosquitto: Socket error on client mqttclientname, disconnecting.
nmqtt: remote closed connection
```

When the connections is closed and reestablished, the queue would still contain the messages. That resulted in:
1) The `waitConfirmation` would wait forever, since the `work.state = WorkSent` wouldn't allow the message to pass throug `work()` - only `WorkNew` is accepted.
2) The msg queue would be filled up with messages never to be used.

To avoid that a checker has been implemented in the `work()`. It currently only deletes the messages, but a goal would be to resend them. It is only activated when the connection is established.
```nim
if connEstablished:
  # Error: Queue contains a qos=1 message. Possible due to break in conn.
  if work.state == WorkSent:
     echo "Error a msg died in the queue"
     delWork.add msgId
```