### PR TITLE
Set default ping interval to 60s

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ import nmqtt, asyncdispatch
 let ctx = newMqttCtx("hallo")
 ctx.set_host("test.mosquitto.org", 1883)
 #ctx.set_auth("username", "password")
+#ctx.set_pint_interval(30)
 
 proc mqttSub() {.async.} =
   await ctx.start()
@@ -69,6 +70,17 @@ Initiate a new MQTT client
 
 ____
 
+## set_ping_interval*
+
+```nim
+proc set_ping_interval*(ctx: MqttCtx, txInterval: int) =
+```
+
+Set the clients ping interval in seconds. Default is 60 seconds.
+
+
+____
+
 ## set_host*
 
 ```nim
@@ -98,8 +110,6 @@ proc start*(ctx: MqttCtx) {.async.} =
 ```
 
 Connect to the host.
-
- You might want to insert a `await sleepAsync 3000`, to let the first pings through before sending.
 
 
 ____

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import nmqtt, asyncdispatch
 let ctx = newMqttCtx("hallo")
 ctx.set_host("test.mosquitto.org", 1883)
 #ctx.set_auth("username", "password")
-#ctx.set_pint_interval(30)
+#ctx.set_ping_interval(30)
 
 proc mqttSub() {.async.} =
   await ctx.start()

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -490,8 +490,6 @@ proc runConnect(ctx: MqttCtx) {.async.} =
             ctx.state = Error
         let ok = await ctx.sendConnect()
         if ok:
-          if ctx.pingTxInterval == 0:
-            ctx.pingTxInterval = 60 * 1000
           asyncCheck ctx.runRx()
           asyncCheck ctx.runPing()
       except OSError as e:
@@ -509,7 +507,7 @@ proc newMqttCtx*(clientId: string): MqttCtx =
 
   MqttCtx(clientId: clientId)
 
-proc set_ping_interval*(ctx: MqttCtx, txInterval: int) =
+proc set_ping_interval*(ctx: MqttCtx, txInterval: int = 6) =
   ## Set the clients ping interval in seconds. Default is 60 seconds.
 
   if txInterval > 0 and txInterval < 65535:
@@ -531,6 +529,8 @@ proc set_auth*(ctx: MqttCtx, username: string, password: string) =
 proc start*(ctx: MqttCtx) {.async.} =
   ## Connect to the host.
 
+  if ctx.pingTxInterval == 0:
+    ctx.set_ping_interval()
   ctx.state = Disconnected
   asyncCheck ctx.runConnect()
   while ctx.state != Connected and ctx.state != Error:

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -507,7 +507,7 @@ proc newMqttCtx*(clientId: string): MqttCtx =
 
   MqttCtx(clientId: clientId)
 
-proc set_ping_interval*(ctx: MqttCtx, txInterval: int = 6) =
+proc set_ping_interval*(ctx: MqttCtx, txInterval: int = 60) =
   ## Set the clients ping interval in seconds. Default is 60 seconds.
 
   if txInterval > 0 and txInterval < 65535:


### PR DESCRIPTION
Set a default ping interval to 60s. Otherwise there's a waiting time on 0. It should not be required for the user to call `set_ping_interval`.

Checks is done within start instead of in `runConnect()` to avoid re-call on disconnect.