### PR TITLE
Param to retain msg

### DIFF
--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -540,11 +540,11 @@ proc start*(ctx: MqttCtx) {.async.} =
   while ctx.state != Connected and ctx.state != Error:
     await sleepAsync 1000
 
-proc publish*(ctx: MqttCtx, topic: string, message: string, qos=0, waitConfirmation = false) {.async.} =
+proc publish*(ctx: MqttCtx, topic: string, message: string, qos=0, retain=false, waitConfirmation = false) {.async.} =
   ## Publish a message
 
   let msgId = ctx.nextMsgId()
-  ctx.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, topic: topic, message: message, qos: qos)
+  ctx.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, topic: topic, qos: qos, message: message, retain: retain)
   await ctx.work()
   if waitConfirmation:
     while ctx.workQueue.len > 0 and hasKey(ctx.workQueue, msgId):


### PR DESCRIPTION
It is currently not possible to set the retain flag when publishing a msg. Include the retain as a param.

@zevv: Do you have any preference for the order of qos and retain in the params? Following mosquitto we are having dup, qos, retain:
```
1584425946: Sending PUBLISH to hallo (d0, q2, r1, m1, 'test1', ... (5 bytes))
```

PR allows for:
```nim
await ctx2.publish("test1", "retainmsg", qos=2, retain=true)
```