### PR TITLE
Split runConnect() into start() and connect()

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ ____
 proc start*(ctx: MqttCtx) {.async.} =
 ```
 
+Auto-connect and reconnect to the host.
+
+
+____
+
+## connect*
+
+```nim
+proc conncet*(ctx: MqttCtx) {.async.} =
+```
+
 Connect to the host.
 
 


### PR DESCRIPTION
This PR:
1) Splits `runConnect()` into a check-for-reconnection-loop and a `connection()`. This allows the user to choose to either use the automated version, `start()`, or the manual `connect()`.
2) Removes the check in `work()` for `if work.state == WorkSent:`. This fixes the test "publish multiple message fast qos=2" in PR #15, which would break due to package handling of qos=2 in `onPubRec()`.
3) Removes default value in `set_ping_interval*()` due being set static in `connectBroker()`.

This PR does not fix:
1) Break of `runConnect()` when state is `Error` (issue #18)
2) Loose of messages when sending qos 1 or 2, and disconnecting before `PUBACK` or `PUBREL/PUBCOMP`.