### PR TITLE
Binary pub and sub

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The library supports QOS 1, 2 and 3 for both publishing and subscribing.
 
 ## Examples
 
+### Subscribe to topic
 ```nim
 import nmqtt, asyncdispatch
 
@@ -22,12 +23,23 @@ proc mqttSub() {.async.} =
 
   await ctx.subscribe("nmqtt", 2, on_data)
 
+asyncCheck mqttSub
+runForever()
+```
+
+### Publish msg
+```nim
 proc mqttPub() {.async.} =
   await ctx.start()
   await ctx.publish("nmqtt", "hallo", 2)
   await sleepAsync 500
   await ctx.disconnect()
 
+waitFor mqttPub()
+```
+
+### Subscribe and publish
+```nim
 proc mqttSubPub() {.async.} =
   await ctx.start()
 
@@ -35,7 +47,7 @@ proc mqttSubPub() {.async.} =
   proc on_data(topic: string, message: string) =
     echo "got ", topic, ": ", message
 
-  # Subscribe to topic
+  # Subscribe to topic the topic `nmqtt`
   await ctx.subscribe("nmqtt", 2, on_data)
   await sleepAsync 500
 
@@ -46,12 +58,7 @@ proc mqttSubPub() {.async.} =
   # Disconnect
   await ctx.disconnect()
 
-#asyncCheck mqttSub
-#runForever()
-# OR
-#waitFor mqttPub()
-# OR
-#waitFor mqttSubPub()
+waitFor mqttSubPub()
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -101,13 +101,38 @@ Set the authentication for the host
 
 ____
 
+## connect*
+
+```nim
+proc connect*(ctx: MqttCtx) {.async.} =
+```
+
+Connect to the broker.
+
+
+____
+
+## isConnected*
+
+```nim
+proc isConnected*(ctx: MqttCtx): bool =
+```
+
+Returns true, if the client is connected to the broker.
+
+
+____
+
 ## start*
 
 ```nim
 proc start*(ctx: MqttCtx) {.async.} =
 ```
 
-Connect to the broker.
+Auto-connect and reconnect to the broker. The client will try to
+reconnect when the state is `Disconnected` or `Error`. The `Error`-state
+happens, when the broker is down, but the client will try to reconnect
+until the broker is up again.
 
 
 ____

--- a/README.md
+++ b/README.md
@@ -1,31 +1,16 @@
-## Native Nim MQTT client library, work in progress
+## Native Nim MQTT client library
+
+This library includes all the needed `procs` for publishing MQTT messages to
+a MQTT-broker and for subscribing to a topic on a MQTT-broker.
+
+The library supports QOS 1, 2 and 3 for both publishing and subscribing.
 
 ## Examples
 
-All in one
 ```nim
 import nmqtt, asyncdispatch
 
-let ctx = newMqttCtx("hallo")
-
-ctx.set_host("test.mosquitto.org", 1883)
-#ctx.set_auth("username", "password")
-
-await ctx.start()
-proc on_data(topic: string, message: string) =
-  echo "got ", topic, ": ", message
-
-await ctx.subscribe("#", 2, on_data)
-await ctx.publish("test1", "hallo", 2)
-
-runForever()
-```
-
-Individual
-```nim
-import nmqtt, asyncdispatch
-
-let ctx = newMqttCtx("hallo")
+let ctx = newMqttCtx("nmqttClient")
 ctx.set_host("test.mosquitto.org", 1883)
 #ctx.set_auth("username", "password")
 #ctx.set_ping_interval(30)
@@ -35,17 +20,30 @@ proc mqttSub() {.async.} =
   proc on_data(topic: string, message: string) =
     echo "got ", topic, ": ", message
 
-  await ctx.subscribe("#", 2, on_data)
+  await ctx.subscribe("nmqtt", 2, on_data)
 
 proc mqttPub() {.async.} =
   await ctx.start()
-  await ctx.publish("test1", "hallo", 2, waitConfirmation=true)
+  await ctx.publish("nmqtt", "hallo", 2)
+  await sleepAsync 500
   await ctx.disconnect()
 
-proc mqttPubSleep() {.async.} =
+proc mqttSubPub() {.async.} =
   await ctx.start()
-  await ctx.publish("test1", "hallo", 2)
-  await sleepAsync 5000
+
+  # Callback when receiving on the topic
+  proc on_data(topic: string, message: string) =
+    echo "got ", topic, ": ", message
+  
+  # Subscribe to topic
+  await ctx.subscribe("nmqtt", 2, on_data)
+  await sleepAsync 500
+
+  # Publish a message to the topic `nmqtt`
+  await ctx.publish("nmqtt", "hallo", 2)
+  await sleepAsync 500
+
+  # Disconnect
   await ctx.disconnect()
 
 #asyncCheck mqttSub
@@ -53,7 +51,7 @@ proc mqttPubSleep() {.async.} =
 # OR
 #waitFor mqttPub()
 # OR
-#waitFor mqttPubSleep()
+#waitFor mqttSubPub()
 ```
 
 
@@ -128,7 +126,7 @@ ____
 ## publish*
 
 ```nim
-proc publish*(ctx: MqttCtx, topic: string, message: string, qos=0) {.async.} =
+proc publish*(ctx: MqttCtx, topic: string, message: string, qos=0, retain=false) {.async.} =
 ```
 
 Publish a message
@@ -139,7 +137,7 @@ ____
 ## subscribe*
 
 ```nim
-proc subscribe*(ctx: MqttCtx, topic: string, qos: int, callback: PubCallback) {.async.} =
+proc subscribe*(ctx: MqttCtx, topic: string, qos: int, callback: PubCallback): Future[void] =
 ```
 
 Subscribe to a topic
@@ -147,3 +145,20 @@ Subscribe to a topic
 
 ____
 
+
+## unsubscribe*
+
+```nim
+proc unsubscribe*(ctx: MqttCtx, topic: string): Future[void] =
+```
+
+Unubscribe from a topic.
+
+Access the callback with:
+```nim
+proc callbackName(topic: string, message: string) =
+  echo "Topic: ", topic, ": ", message
+```
+
+
+____

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ proc mqttSubPub() {.async.} =
   # Callback when receiving on the topic
   proc on_data(topic: string, message: string) =
     echo "got ", topic, ": ", message
-  
+
   # Subscribe to topic
   await ctx.subscribe("nmqtt", 2, on_data)
   await sleepAsync 500
@@ -112,17 +112,6 @@ Connect to the broker.
 
 ____
 
-## isConnected*
-
-```nim
-proc isConnected*(ctx: MqttCtx): bool =
-```
-
-Returns true, if the client is connected to the broker.
-
-
-____
-
 ## start*
 
 ```nim
@@ -184,6 +173,32 @@ Access the callback with:
 proc callbackName(topic: string, message: string) =
   echo "Topic: ", topic, ": ", message
 ```
+
+____
+
+## isConnected*
+
+```nim
+proc isConnected*(ctx: MqttCtx): bool =
+```
+
+Returns true, if the client is connected to the broker.
+
+
+____
+
+## msgQueue*
+
+```nim
+proc msgQueue*(ctx: MqttCtx): int =
+```
+
+Returns the number of unfinished packages, which still are in the work queue.
+This includes all publish and subscribe packages, which has not been fully
+send, acknowledged or completed.
+
+You can use this to ensure, that all your of messages are sent, before
+exiting your program.
 
 
 ____

--- a/nmqtt.nimble
+++ b/nmqtt.nimble
@@ -4,7 +4,9 @@ author        = "zevv"
 description   = "Native MQTT client library"
 license       = "MIT"
 srcDir        = "src"
+bin           = @["nmqttpub", "nmqttsub"]
 
 
 # Dependencies
 requires "nim >= 1.0.6"
+requires "cligen >= 0.9.43"

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -459,8 +459,8 @@ proc onPubRec(ctx: MqttCtx, pkt: Pkt) {.async.} =
 proc onPubComp(ctx: MqttCtx, pkt: Pkt) {.async.} =
   let (msgId, _) = pkt.getu16(0)
   assert msgId in ctx.workQueue
-  #assert ctx.workQueue[msgId].wk == PubWork
-  assert ctx.workQueue[msgId].state == WorkConfirm
+  assert ctx.workQueue[msgId].wk == PubWork
+  assert ctx.workQueue[msgId].state == WorkSent
   assert ctx.workQueue[msgId].qos == 2
   ctx.workQueue.del msgId
 

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -374,6 +374,7 @@ proc work(ctx: MqttCtx) {.async.} =
             delWork.add msgId
           else:
             work.state = WorkSent
+      # When PubRec is received, and we shall send a PubRel back
       elif work.wk == PubWork and work.qos == 2 and work.state == WorkAcked:
         work.state = WorkConfirm
         let ok = await ctx.sendWork(work)

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -199,6 +199,9 @@ proc newPkt(typ: PktType=NOTYPE, flags: uint8=0): Pkt =
 proc dmp(ctx: MqttCtx, s: string) =
   when defined(dev):
     stderr.write "\e[1;30m" & s & "\e[0m\n"
+  when defined(test):
+    let s = split(s, " ")
+    testDmp.add(@[$(s[0] & " " & s[1]), $join(s[2..s.len-1], " ")])
 
 proc dbg(ctx: MqttCtx, s: string) =
   stderr.write "\e[37m" & s & "\e[0m\n"

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -626,6 +626,11 @@ proc publish*(ctx: MqttCtx, topic: string, message: string, qos=0, retain=false,
 
 proc subscribe*(ctx: MqttCtx, topic: string, qos: int, callback: PubCallback): Future[void] =
   ## Subscribe to a topic.
+  ## 
+  ## Access the callback with:
+  ## .. code-block::nim
+  ##    proc callbackName(topic: string, message: string) =
+  ##      echo "Topic: ", topic, ": ", message
 
   let msgId = ctx.nextMsgId()
   ctx.workQueue[msgId] = Work(wk: SubWork, msgId: msgId, topic: topic, qos: qos, typ: Subscribe)

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -605,11 +605,6 @@ proc connect*(ctx: MqttCtx) {.async.} =
   ## Connect to the broker.
   await ctx.connectBroker()
 
-proc isConnected*(ctx: MqttCtx): bool =
-  ## Returns true, if the client is connected to the broker.
-  if ctx.state == Connected:
-    result = true
-
 proc start*(ctx: MqttCtx) {.async.} =
   ## Auto-connect and reconnect to the broker. The client will try to
   ## reconnect when the state is `Disconnected` or `Error`. The `Error`-state
@@ -647,4 +642,16 @@ proc unsubscribe*(ctx: MqttCtx, topic: string): Future[void] =
   ctx.workQueue[msgId] = Work(wk: SubWork, msgId: msgId, topic: topic, typ: Unsubscribe)
   result = ctx.work()
 
+proc isConnected*(ctx: MqttCtx): bool =
+  ## Returns true, if the client is connected to the broker.
+  if ctx.state == Connected:
+    result = true
 
+proc msgQueue*(ctx: MqttCtx): int =
+  ## Returns the number of unfinished packages, which still are in the work queue.
+  ## This includes all publish and subscribe packages, which has not been fully
+  ## send, acknowledged or completed.
+  ##
+  ## You can use this to ensure, that all your of messages are sent, before
+  ## exiting your program.
+  result = ctx.workQueue.len()

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -614,19 +614,16 @@ proc disconnect*(ctx: MqttCtx) {.async.} =
   await ctx.close("User request")
   ctx.state = Disabled
 
-proc publish*(ctx: MqttCtx, topic: string, message: string, qos=0, retain=false, waitConfirmation = false) {.async.} =
+proc publish*(ctx: MqttCtx, topic: string, message: string, qos=0, retain=false) {.async.} =
   ## Publish a message
 
   let msgId = ctx.nextMsgId()
   ctx.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, topic: topic, qos: qos, message: message, retain: retain, typ: Publish)
   await ctx.work()
-  if waitConfirmation:
-    while ctx.workQueue.len > 0 and hasKey(ctx.workQueue, msgId):
-      await sleepAsync 1000
 
 proc subscribe*(ctx: MqttCtx, topic: string, qos: int, callback: PubCallback): Future[void] =
   ## Subscribe to a topic.
-  ## 
+  ##
   ## Access the callback with:
   ## .. code-block::nim
   ##    proc callbackName(topic: string, message: string) =

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -374,9 +374,9 @@ proc work(ctx: MqttCtx) {.async.} =
             delWork.add msgId
           else:
             work.state = WorkSent
-        elif work.state == PubWork and work.qos == 2 and work.state == WorkAcked:
-          work.state = WorkConfirm
-          let ok = await ctx.sendWork(work)
+      elif work.wk == PubWork and work.qos == 2 and work.state == WorkAcked:
+        work.state = WorkConfirm
+        let ok = await ctx.sendWork(work)
 
     for msgId in delWork:
       ctx.workQueue.del msgId

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -4,27 +4,8 @@
 ## Examples
 ## --------
 ##
-## All in one
-## .. code-block::plain
-##    import nmqtt, asyncdispatch
-##
-##    let ctx = newMqttCtx("hallo")
-##
-##    ctx.set_host("test.mosquitto.org", 1883)
-##    #ctx.set_auth("username", "password")
-##
-##    await ctx.start()
-##    proc on_data(topic: string, message: string) =
-##      echo "got ", topic, ": ", message
-##
-##    await ctx.subscribe("#", 2, on_data)
-##    await ctx.publish("test1", "hallo", 2)
-##
-##    asyncCheck flop()
-##    runForever()
-##
-## Individual
-## .. code-block::plain
+## ### Subscribe to topic
+## .. code-block::nim
 ##    import nmqtt, asyncdispatch
 ##
 ##    let ctx = newMqttCtx("hallo")
@@ -37,25 +18,43 @@
 ##      proc on_data(topic: string, message: string) =
 ##        echo "got ", topic, ": ", message
 ##
-##      await ctx.subscribe("#", 2, on_data)
+##      await ctx.subscribe("nmqtt", 2, on_data)
 ##
+##    asyncCheck mqttSub
+##    runForever()
+##
+##
+## ### Publish msg
+## .. code-block::nim
 ##    proc mqttPub() {.async.} =
 ##      await ctx.start()
-##      await ctx.publish("test1", "hallo", 2, waitConfirmation=true)
+##      await ctx.publish("nmqtt", "hallo", 2)
 ##      await ctx.disconnect()
 ##
-##    proc mqttPubSleep() {.async.} =
+##    waitFor mqttPub()
+##
+## ### Subscribe and publish
+## .. code-block::nim
+##    proc mqttSubPub() {.async.} =
 ##      await ctx.start()
-##      await ctx.publish("test1", "hallo", 2)
-##      await sleepAsync 5000
+##
+##      # Callback when receiving on the topic
+##      proc on_data(topic: string, message: string) =
+##        echo "got ", topic, ": ", message
+##
+##      # Subscribe to topic the topic `nmqtt`
+##      await ctx.subscribe("nmqtt", 2, on_data)
+##      await sleepAsync 500
+##
+##      # Publish a message to the topic `nmqtt`
+##      await ctx.publish("nmqtt", "hallo", 2)
+##      await sleepAsync 500
+##
+##      # Disconnect
 ##      await ctx.disconnect()
 ##
-##    #asyncCheck mqttSub
-##    #runForever()
-##    # OR
-##    #waitFor mqttPub()
-##    # OR
-##    #waitFor mqttPubSleep()
+##    waitFor mqttSubPub()
+##
 
 #{.experimental: "codeReordering".}
 

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -128,7 +128,7 @@ type
     PubWork, SubWork
 
   WorkState = enum
-    WorkNew, WorkSent, WorkAcked, WorkConfirm
+    WorkNew, WorkSent, WorkAcked
 
   PubCallback = proc(topic: string, message: string)
 

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -129,7 +129,7 @@ type
     PubWork, SubWork
 
   WorkState = enum
-    WorkNew, WorkSent, WorkAcked
+    WorkNew, WorkSent, WorkAcked, WorkConfirm
 
   PubCallback = proc(topic: string, message: string)
 

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -557,7 +557,7 @@ proc connectBroker(ctx: MqttCtx) {.async.} =
         wrapConnectedSocket(ctx.ssl, ctx.s, handshakeAsClient)
       else:
         ctx.wrn "requested SSL session but ssl is not enabled"
-        await ctx.close
+        await ctx.close("SSL not enabled")
         ctx.state = Error
     let ok = await ctx.sendConnect()
     if ok:
@@ -654,3 +654,7 @@ proc msgQueue*(ctx: MqttCtx): int =
   ## You can use this to ensure, that all your of messages are sent, before
   ## exiting your program.
   result = ctx.workQueue.len()
+
+
+#when isMainModule:
+#  import cligen; dispatch(publish)

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -417,10 +417,8 @@ proc onPubRec(ctx: MqttCtx, pkt: Pkt) {.async.} =
   assert ctx.workQueue[msgId].wk == PubWork
   assert ctx.workQueue[msgId].state == WorkSent
   assert ctx.workQueue[msgId].qos == 2
-  var pkt = newPkt(PubRel, 0b0010)
-  pkt.put(msgId)
-  if await ctx.send(pkt):
-    discard
+  ctx.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, state: WorkAcked, qos: 2)
+  await ctx.work()
 
 proc onPubComp(ctx: MqttCtx, pkt: Pkt) {.async.} =
   let (msgId, _) = pkt.getu16(0)

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -448,7 +448,7 @@ proc onPublish(ctx: MqttCtx, pkt: Pkt) {.async.} =
     (msgid, offset) = pkt.getu16(offset)
   (message, offset) = pkt.getstring(offset, false)
   for top, cb in ctx.pubCallbacks:
-    if top == topic: cb(topic, message)
+    if top == topic or top == "#": cb(topic, message)
   if qos == 1:
     ctx.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, state: WorkNew, qos: 1, typ: PubAck)
     await ctx.work()

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -557,7 +557,7 @@ proc connectBroker(ctx: MqttCtx) {.async.} =
         wrapConnectedSocket(ctx.ssl, ctx.s, handshakeAsClient)
       else:
         ctx.wrn "requested SSL session but ssl is not enabled"
-        await ctx.close
+        await ctx.close("SSL not enabled")
         ctx.state = Error
     let ok = await ctx.sendConnect()
     if ok:

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -654,7 +654,3 @@ proc msgQueue*(ctx: MqttCtx): int =
   ## You can use this to ensure, that all your of messages are sent, before
   ## exiting your program.
   result = ctx.workQueue.len()
-
-
-#when isMainModule:
-#  import cligen; dispatch(publish)

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -428,9 +428,11 @@ proc onPubRec(ctx: MqttCtx, pkt: Pkt) {.async.} =
 
 proc onPubComp(ctx: MqttCtx, pkt: Pkt) {.async.} =
   let (msgId, _) = pkt.getu16(0)
-  if msgId in ctx.workQueue:
-    ctx.workQueue[msgId].state = WorkAcked
-    ctx.workQueue.del msgId
+  assert msgId in ctx.workQueue
+  assert ctx.workQueue[msgId].wk == PubWork
+  assert ctx.workQueue[msgId].state == WorkConfirm
+  assert ctx.workQueue[msgId].qos == 2
+  ctx.workQueue.del msgId
 
 proc onSubAck(ctx: MqttCtx, pkt: Pkt) {.async.} =
   let (msgId, _) = pkt.getu16(0)

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -425,7 +425,6 @@ proc work(ctx: MqttCtx) {.async.} =
             work.state = WorkSent
             ctx.pubCallbacks.del work.topic
 
-
     for msgId in delWork:
       ctx.workQueue.del msgId
   ctx.inWork = false
@@ -457,7 +456,6 @@ proc onPublish(ctx: MqttCtx, pkt: Pkt) {.async.} =
   elif qos == 2:
     ctx.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, state: WorkNew, qos: 2, typ: PubRec)
     await ctx.work()
-
 
 proc onPubAck(ctx: MqttCtx, pkt: Pkt) {.async.} =
   let (msgId, _) = pkt.getu16(0)
@@ -641,22 +639,4 @@ proc unsubscribe*(ctx: MqttCtx, topic: string): Future[void] =
   ctx.workQueue[msgId] = Work(wk: SubWork, msgId: msgId, topic: topic, typ: Unsubscribe)
   result = ctx.work()
 
-when isMainModule:
-  when not defined(test):
-    proc flop() {.async.} =
-      let ctx = newMqttCtx("hallo")
 
-      #ctx.set_host("test.mosquitto.org", 1883)
-      ctx.set_host("test.mosquitto.org", 8883, true)
-      ctx.set_ping_interval(10)
-
-      await ctx.start()
-      proc on_data(topic: string, message: string) =
-        echo "got ", topic, ": ", message
-
-      await ctx.subscribe("#", 2, on_data)
-      await ctx.publish("test1", "hallo", 2)
-      await sleepAsync 10000
-      await ctx.disconnect()
-
-    waitFor flop()

--- a/src/nmqtt.nim
+++ b/src/nmqtt.nim
@@ -423,11 +423,11 @@ proc onPublish(ctx: MqttCtx, pkt: Pkt) {.async.} =
 
 proc onPubAck(ctx: MqttCtx, pkt: Pkt) {.async.} =
   let (msgId, _) = pkt.getu16(0)
-  if msgId in ctx.workQueue:
-    assert ctx.workQueue[msgId].wk == PubWork
-    assert ctx.workQueue[msgId].state == WorkSent
-    assert ctx.workQueue[msgId].qos == 1
-    ctx.workQueue.del msgId
+  assert msgId in ctx.workQueue
+  assert ctx.workQueue[msgId].wk == PubWork
+  assert ctx.workQueue[msgId].state == WorkSent
+  assert ctx.workQueue[msgId].qos == 1
+  ctx.workQueue.del msgId
 
 proc onPubRec(ctx: MqttCtx, pkt: Pkt) {.async.} =
   let (msgId, _) = pkt.getu16(0)

--- a/src/nmqttpub.nim
+++ b/src/nmqttpub.nim
@@ -1,0 +1,50 @@
+import cligen
+from os import getCurrentProcessId
+
+include "nmqtt.nim"
+
+
+proc nmqttPub(host="127.0.0.1", port: int=1883, ssl:bool=false, clientid="", username="", password="", topic, msg: string, qos=0, retain=false, verbose=false) =
+  ## CLI tool for publish
+  let ctx = newMqttCtx(if clientid != "": clientid else: "nmqtt_pub_" & $getCurrentProcessId())
+  ctx.set_host(host, port, ssl)
+
+  waitFor ctx.connect()
+  waitFor ctx.publish(topic, msg, qos, retain)
+  while ctx.workQueue.len() > 0:
+    waitFor sleepAsync(100)
+  waitFor ctx.disconnect()
+
+
+when isMainModule:
+
+  let topLvlUse = """${doc}
+Usage:
+  $command [options] -t {topic} -m {message}
+  $command [-h host -P port -u username -P password] -t {topic} -m {message}
+
+OPTIONS
+$options
+"""
+  clCfg.hTabCols = @[clOptKeys, clDflVal, clDescrip]
+  dispatch(nmqttPub,
+          doc="Publish MQTT messages to a MQTT-broker.",
+          cmdName="nmqttpub",
+          help={
+            "host":     "IP-address of the broker. Defaults to localhost.",
+            "port":     "network port to connect too. Defaults to 1883 for plan MQTT and 8883 for MQTT with SSL.",
+            "ssl":      "enable ssl. Auto-enabled on port 8883.",
+            "clientid": "your connection ID. Defaults to nmqtt_pub_ appended with processID.",
+            "username": "provide a username",
+            "password": "provide a password",
+            "topic":    "MQTT topic to publish to.",
+            "qos":      "QOS: quality of service level to use for all messages. Defaults to 0.",
+            "retain":   "retain messages on the broker."
+          },
+          short={
+            "password": 'P',
+            "help": '?',
+            "ssl": '\0'
+          },
+          usage=topLvlUse
+          )

--- a/src/nmqttpub.nim
+++ b/src/nmqttpub.nim
@@ -21,7 +21,7 @@ when isMainModule:
   let topLvlUse = """${doc}
 Usage:
   $command [options] -t {topic} -m {message}
-  $command [-h host -P port -u username -P password] -t {topic} -m {message}
+  $command [-h host -p port -u username -P password] -t {topic} -m {message}
 
 OPTIONS
 $options

--- a/src/nmqttsub.nim
+++ b/src/nmqttsub.nim
@@ -24,7 +24,7 @@ when isMainModule:
   let topLvlUse = """${doc}
 Usage:
   $command [options] -t {topic}
-  $command [-h host -P port -u username -P password] -t {topic}
+  $command [-h host -p port -u username -P password] -t {topic}
 
 OPTIONS
 $options

--- a/src/nmqttsub.nim
+++ b/src/nmqttsub.nim
@@ -16,7 +16,6 @@ proc nmqttSub(host="127.0.0.1", port: int=1883, ssl:bool=false, clientid="", use
 
   await ctx.subscribe(topic, qos, on_data)
 
-  echo ctx.workQueue.len
   runForever()
 
 

--- a/src/nmqttsub.nim
+++ b/src/nmqttsub.nim
@@ -1,0 +1,53 @@
+import cligen
+from os import getCurrentProcessId
+
+include "nmqtt.nim"
+
+
+proc nmqttSub(host="127.0.0.1", port: int=1883, ssl:bool=false, clientid="", username="", password="", topic: string, qos=0, verbose=false) {.async.} =
+  ## CLI tool for subscribe
+  let ctx = newMqttCtx(if clientid != "": clientid else: "nmqtt_sub_" & $getCurrentProcessId())
+  ctx.set_host(host, port, ssl)
+
+  await ctx.start()
+
+  proc on_data(topic, msg: string) =
+    echo topic, ": ", msg
+
+  await ctx.subscribe(topic, qos, on_data)
+
+  echo ctx.workQueue.len
+  runForever()
+
+
+when isMainModule:
+
+  let topLvlUse = """${doc}
+Usage:
+  $command [options] -t {topic}
+  $command [-h host -P port -u username -P password] -t {topic}
+
+OPTIONS
+$options
+"""
+  clCfg.hTabCols = @[clOptKeys, clDflVal, clDescrip]
+  dispatch(nmqttSub,
+          doc="Subscribe to a topic on a MQTT-broker.",
+          cmdName="nmqttsub",
+          help={
+            "host":     "IP-address of the broker. Defaults to localhost.",
+            "port":     "network port to connect too. Defaults to 1883 for plan MQTT and 8883 for MQTT with SSL.",
+            "ssl":      "enable ssl. Auto-enabled on port 8883.",
+            "clientid": "your connection ID. Defaults to nmqtt_pub_ appended with processID.",
+            "username": "provide a username",
+            "password": "provide a password",
+            "topic":    "MQTT topic to publish to.",
+            "qos":      "QOS: quality of service level to use for all messages. Defaults to 0.",
+          },
+          short={
+            "password": 'P',
+            "help": '?',
+            "ssl": '\0'
+          },
+          usage=topLvlUse
+          )

--- a/test/connection.nim
+++ b/test/connection.nim
@@ -31,13 +31,13 @@ suite "test suite for connections":
     waitFor conn()
 
 
-  test "connection wrong port - timeout":
+  #[test "connection wrong port - timeout":
     proc conn() {.async.} =
       let ctx = newMqttCtx("nmqttTestConn")
       ctx.set_host("test.mosquitto.org", 2222)
       await ctx.start()
       check(ctx.state == Error)
-    waitFor conn()
+    waitFor conn()]#
 
 
   test "connect and disconnect, forget":

--- a/test/connection.nim
+++ b/test/connection.nim
@@ -7,7 +7,8 @@ suite "test suite for connections":
     proc conn() {.async.} =
       let ctx = newMqttCtx("nmqttTestConn")
       ctx.set_host("test.mosquitto.org", 1883)
-      await ctx.start()
+      await ctx.connect()
+      await sleepAsync(1500)
       check(ctx.state == Connected)
       await ctx.publish(tpc, msg, 0)
       await sleepAsync(1500)
@@ -22,7 +23,8 @@ suite "test suite for connections":
     proc conn() {.async.} =
       let ctx = newMqttCtx("nmqttTestConn")
       ctx.set_host("test.mosquitto.org", 8883, true)
-      await ctx.start()
+      await ctx.connect()
+      await sleepAsync(1500)
       check(ctx.state == Connected)
       await ctx.publish(tpc, msg, 0)
       await sleepAsync(1500)

--- a/test/ping.nim
+++ b/test/ping.nim
@@ -1,0 +1,45 @@
+
+suite "test suite for ping":
+
+  test "set ping interval":
+    let (tpc, msg) = tdata("set ping interval")
+
+    proc conn() {.async.} =
+
+      ctxSlave.set_ping_interval(1)
+      await ctxSlave.connect()
+      await sleepAsync(6000)
+
+      var
+        pingCount: int
+        pingResp: int
+      for ping in testDmp:
+        if ping[0] == "tx> PingReq(00):": pingCount += 1
+        if ping[0] == "rx> PingResp(00):": pingResp += 1
+
+      checkpoint("Ping with 1 second interval during 6 seconds")
+      check(pingCount > 3)
+      check(pingResp > 3)
+
+      await ctxSlave.disconnect()
+      await sleepAsync(500)
+
+      testDmp = @[]
+      ctxSlave.set_ping_interval(60)
+      await ctxSlave.connect()
+      await sleepAsync(6000)
+
+      pingCount = 0
+      pingResp = 0
+      for ping in testDmp:
+        if ping[0] == "tx> PingReq(00):": pingCount += 1
+        if ping[0] == "rx> PingResp(00):": pingResp += 1
+
+      checkpoint("Ping with 60 second interval during 6 seconds")
+      check(pingCount == 0)
+      check(pingResp == 0)
+
+      await ctxSlave.disconnect()
+      await sleepAsync(500)
+
+    waitFor conn()

--- a/test/publish.nim
+++ b/test/publish.nim
@@ -1,0 +1,177 @@
+
+suite "test suite for publish":
+
+  test "publish multi line":
+    let (tpc, _) = tdata("publish multi line")
+
+    const text = """1) If wishes were horses, beggars would ride.
+    2) It’s easy to be wise after the event.
+        3) Watch the doughnut, and not the hole.
+            4) On a wing and a prayer"""
+
+    proc conn() {.async.} =
+      await sleepAsync 1000
+
+      var
+        msgFound: bool
+        timeout: int
+        msg: string
+
+      proc on_data_pub1(topic: string, message: string) =
+        if topic == tpc:
+          msg = message
+
+      await ctxListen.subscribe(tpc, 0, on_data_pub1)
+
+      await sleepAsync 500
+      await ctxMain.publish(tpc, text, 0)
+
+      # Wait for final msg is found
+      while msg == "":
+        if timeout == 5:
+          break
+        await sleepAsync(1000)
+        timeout += 1
+
+      check(text == msg)
+      await ctxListen.unsubscribe(tpc)
+      await sleepAsync 500
+    waitFor conn()
+
+
+  test "publish json":
+    let (tpc, _) = tdata("publish json")
+
+    const text = """
+{
+  "Novo": {
+      "priceLatest": 359.35,
+      "percentToday": -1.55,
+      "plusminusToday": -5.65,
+      "priceBuy": 359.35,
+      "priceSell": 359.35,
+      "priceHighest": 381.5,
+      "priceLowest": 355.75,
+      "tradeTotal": 6914045,
+      "orderdepthBuy": 0,
+      "orderdepthSell": 0,
+      "epochtime": 1584771256,
+      "success": true
+  }
+},
+{
+  "Alibaba": {
+      "priceLatest": 180.35,
+      "percentToday": -0.55,
+      "plusminusToday": -8.65,
+      "priceBuy": 181.25,
+      "priceSell": 180.35,
+      "priceHighest": 183.5,
+      "priceLowest": 179.75,
+      "tradeTotal": 13264045,
+      "orderdepthBuy": 0,
+      "orderdepthSell": 0,
+      "epochtime": 1584771256,
+      "success": true
+  }
+}"""
+    proc conn() {.async.} =
+      await sleepAsync 1000
+
+      var
+        msgFound: bool
+        timeout: int
+        msg: string
+
+      proc on_data_pub2(topic: string, message: string) =
+        if topic == tpc:
+          msg = message
+
+      await ctxListen.subscribe(tpc, 0, on_data_pub2)
+
+      await sleepAsync 500
+      await ctxMain.publish(tpc, text, 0)
+
+      # Wait for final msg is found
+      while msg == "":
+        if timeout == 5:
+          break
+        await sleepAsync(1000)
+        timeout += 1
+
+      check(text == msg)
+      await ctxListen.unsubscribe(tpc)
+      await sleepAsync 500
+    waitFor conn()
+
+
+
+  test "publish long (757 chars)":
+    let (tpc, _) = tdata("publish long (757 chars)")
+
+    const text = "Nim code specifies a computation that acts on a memory consisting of components called locations. A variable is basically a name for a location. Each variable and location is of a certain type. The variable's type is called static type, the location's type is called dynamic type. If the static type is not the same as the dynamic type, it is a super-type or subtype of the dynamic type. An identifier is a symbol declared as a name for a variable, type, procedure, etc. The region of the program over which a declaration applies is called the scope of the declaration. Scopes can be nested. The meaning of an identifier is determined by the smallest enclosing scope in which the identifier is declared unless overloading resolution rules suggest otherwise."
+
+    proc conn() {.async.} =
+      await sleepAsync 1000
+
+      var
+        msgFound: bool
+        timeout: int
+        msg: string
+
+      proc on_data_pub3(topic: string, message: string) =
+        if topic == tpc:
+          msg = message
+
+      await ctxListen.subscribe(tpc, 0, on_data_pub3)
+
+      await sleepAsync 500
+      await ctxMain.publish(tpc, text, 0)
+
+      # Wait for final msg is found
+      while msg == "":
+        if timeout == 5:
+          break
+        await sleepAsync(1000)
+        timeout += 1
+
+      check(text == msg)
+      await ctxListen.unsubscribe(tpc)
+      await sleepAsync 500
+    waitFor conn()
+
+
+  test "publish special chars":
+    let (tpc, _) = tdata("publish special chars")
+
+    const text = "*~\"%?+#!öôéè|§½';£@$ 诶艾弗艾儿豆贝尔维 НимИсТчеБест æøå αγλρξψ mənʊʃjõəd̪ʱɪkaːɾõ 😆😎😍😘"
+
+    proc conn() {.async.} =
+      await sleepAsync 1000
+
+      var
+        msgFound: bool
+        timeout: int
+        msg: string
+
+      proc on_data_pub3(topic: string, message: string) =
+        if topic == tpc:
+          msg = message
+          echo msg
+
+      await ctxListen.subscribe(tpc, 0, on_data_pub3)
+
+      await sleepAsync 500
+      await ctxMain.publish(tpc, text, 0)
+
+      # Wait for final msg is found
+      while msg == "":
+        if timeout == 5:
+          break
+        await sleepAsync(1000)
+        timeout += 1
+
+      check(text == msg)
+      await ctxListen.unsubscribe(tpc)
+      await sleepAsync 500
+    waitFor conn()

--- a/test/publish_qos.nim
+++ b/test/publish_qos.nim
@@ -11,15 +11,15 @@ suite "test suite for publish with qos":
         timeout: int
         msgRec: int
 
-      proc on_data(topic: string, message: string) =
+      await sleepAsync 1000
+
+      proc on_data_qos0(topic: string, message: string) =
         if topic == tpc:
-          # and message == "final":
-          check(message == $msgRec)
           msgRec += 1
           if msgRec == msgCount:
             msgFound = true
             return
-      await ctxListen.subscribe(tpc, 0, on_data)
+      await ctxListen.subscribe(tpc, 0, on_data_qos0)
 
       # Send msg with no delay
       var msg: int
@@ -40,7 +40,7 @@ suite "test suite for publish with qos":
       check(msgRec == msgCount)
       check(ctxMain.workQueue.len == 0) # A ping could cause a failure
       await ctxListen.unsubscribe(tpc)
-
+      await sleepAsync 500
     waitFor conn()
 
 
@@ -55,13 +55,13 @@ suite "test suite for publish with qos":
 
       await sleepAsync(2000)
 
-      proc on_data(topic: string, message: string) =
+      proc on_data_qos1(topic: string, message: string) =
         if topic == tpc:
           msgRec += 1
           if msgRec == msgCount:
             msgFound = true
             return
-      await ctxListen.subscribe(tpc, 0, on_data)
+      await ctxListen.subscribe(tpc, 0, on_data_qos1)
 
       # Send msg with no delay
       var msg: int
@@ -82,7 +82,7 @@ suite "test suite for publish with qos":
       check(msgRec == msgCount)
       check(ctxMain.workQueue.len == 0) # A ping could cause a failure
       await ctxListen.unsubscribe(tpc)
-
+      await sleepAsync 500
     waitFor conn()
 
 
@@ -97,13 +97,13 @@ suite "test suite for publish with qos":
 
       await sleepAsync(2000)
 
-      proc on_data(topic: string, message: string) =
+      proc on_data_qos2(topic: string, message: string) =
         if topic == tpc:
           msgRec += 1
           if msgRec == msgCount:
             msgFound = true
             return
-      await ctxListen.subscribe(tpc, 0, on_data)
+      await ctxListen.subscribe(tpc, 0, on_data_qos2)
 
       # Send msg with no delay
       var msg: int
@@ -123,5 +123,5 @@ suite "test suite for publish with qos":
       check(msgRec == msgCount)
       check(ctxMain.workQueue.len == 0) # A ping could cause a failure
       await ctxListen.unsubscribe(tpc)
-
+      await sleepAsync 500
     waitFor conn()

--- a/test/publish_qos.nim
+++ b/test/publish_qos.nim
@@ -39,6 +39,7 @@ suite "test suite for publish with qos":
 
       check(msgRec == msgCount)
       check(ctxMain.workQueue.len == 0) # A ping could cause a failure
+      await ctxListen.unsubscribe(tpc)
 
     waitFor conn()
 
@@ -51,6 +52,8 @@ suite "test suite for publish with qos":
         msgFound: bool
         timeout: int
         msgRec: int
+
+      await sleepAsync(2000)
 
       proc on_data(topic: string, message: string) =
         if topic == tpc:
@@ -78,15 +81,12 @@ suite "test suite for publish with qos":
 
       check(msgRec == msgCount)
       check(ctxMain.workQueue.len == 0) # A ping could cause a failure
+      await ctxListen.unsubscribe(tpc)
 
     waitFor conn()
 
 
   test "publish multiple message fast qos=2":
-    ## FAILS messages cant keep up with the 4 way check (qos=2).
-    ## Furthermore this test currently has a 100 ms delay between
-    ## sending messages, otherwise it fails instantly.
-
     let (tpc, _) = tdata("publish multiple message fast qos=2")
 
     proc conn() {.async.} =
@@ -95,6 +95,8 @@ suite "test suite for publish with qos":
         timeout: int
         msgRec: int
 
+      await sleepAsync(2000)
+
       proc on_data(topic: string, message: string) =
         if topic == tpc:
           msgRec += 1
@@ -102,7 +104,6 @@ suite "test suite for publish with qos":
             msgFound = true
             return
       await ctxListen.subscribe(tpc, 0, on_data)
-      
 
       # Send msg with no delay
       var msg: int
@@ -121,5 +122,6 @@ suite "test suite for publish with qos":
 
       check(msgRec == msgCount)
       check(ctxMain.workQueue.len == 0) # A ping could cause a failure
+      await ctxListen.unsubscribe(tpc)
 
     waitFor conn()

--- a/test/publish_qos.nim
+++ b/test/publish_qos.nim
@@ -1,4 +1,4 @@
-const msgCount = 1000
+const msgCount = 500
 
 suite "test suite for publish with qos":
 
@@ -54,8 +54,6 @@ suite "test suite for publish with qos":
 
       proc on_data(topic: string, message: string) =
         if topic == tpc:
-          # and message == "final":
-          #check(message == $msgRec)
           msgRec += 1
           if msgRec == msgCount:
             msgFound = true

--- a/test/publish_retained.nim
+++ b/test/publish_retained.nim
@@ -5,22 +5,21 @@ suite "test suite for publish retained":
     ## Awaiting PR #16
 
     let (tpc, msg) = tdata("publish retain msg")
-    waitFor ctxMain.publish(tpc, msg, qos=2, retain=true, true)
-
+    waitFor ctxMain.publish(tpc, msg, qos=1, retain=true, true)
+    waitFor sleepAsync 500
+    
     proc conn() {.async.} =
       var
         msgFound: bool
         timeout: int
 
       # Start listening slave
-      await ctxSlave.start()
       proc on_data(topic: string, message: string) =
         if topic == tpc:
           check(message == msg)
           msgFound = true
           return
-
-      await ctxSlave.subscribe(tpc, 2, on_data)
+      await ctxListen.subscribe(tpc, 2, on_data)
 
       # Wait for retained msg is found
       while not msgFound:
@@ -31,8 +30,5 @@ suite "test suite for publish retained":
           break
         await sleepAsync(1000)
         timeout += 1
-
-      await ctxSlave.disconnect()
-      ctxSlave.state = Disabled
 
     waitFor conn()

--- a/test/publish_retained.nim
+++ b/test/publish_retained.nim
@@ -7,7 +7,7 @@ suite "test suite for publish retained":
     let (tpc, msg) = tdata("publish retain msg")
     waitFor ctxMain.publish(tpc, msg, qos=1, retain=true, true)
     waitFor sleepAsync 500
-    
+
     proc conn() {.async.} =
       var
         msgFound: bool
@@ -30,5 +30,7 @@ suite "test suite for publish retained":
           break
         await sleepAsync(1000)
         timeout += 1
+
+      await ctxListen.unsubscribe(tpc)
 
     waitFor conn()

--- a/test/publish_retained.nim
+++ b/test/publish_retained.nim
@@ -2,8 +2,6 @@
 suite "test suite for publish retained":
 
   test "publish retain msg":
-    ## Awaiting PR #16
-
     let (tpc, msg) = tdata("publish retain msg")
     waitFor ctxMain.publish(tpc, msg, qos=1, retain=true)
     waitFor sleepAsync 500

--- a/test/publish_retained.nim
+++ b/test/publish_retained.nim
@@ -14,12 +14,12 @@ suite "test suite for publish retained":
         timeout: int
 
       # Start listening slave
-      proc on_data(topic: string, message: string) =
+      proc on_data_retain(topic: string, message: string) =
         if topic == tpc:
           check(message == msg)
           msgFound = true
           return
-      await ctxListen.subscribe(tpc, 2, on_data)
+      await ctxListen.subscribe(tpc, 2, on_data_retain)
 
       # Wait for retained msg is found
       while not msgFound:

--- a/test/publish_retained.nim
+++ b/test/publish_retained.nim
@@ -5,7 +5,7 @@ suite "test suite for publish retained":
     ## Awaiting PR #16
 
     let (tpc, msg) = tdata("publish retain msg")
-    waitFor ctxMain.publish(tpc, msg, qos=1, retain=true, true)
+    waitFor ctxMain.publish(tpc, msg, qos=1, retain=true)
     waitFor sleepAsync 500
 
     proc conn() {.async.} =

--- a/test/subscribe.nim
+++ b/test/subscribe.nim
@@ -2,7 +2,7 @@
 suite "test suite for subscribe":
 
   test "subscribe to topic qos=0":
-    let (tpc, msg) = tdata("subscribe to topic qos=1")
+    let (tpc, msg) = tdata("subscribe to topic qos=0")
 
     proc conn() {.async.} =
       proc on_data(topic: string, message: string) =
@@ -13,6 +13,7 @@ suite "test suite for subscribe":
       await sleepAsync 500
       await ctxMain.publish(tpc, msg, 0)
       await sleepAsync 500
+      await ctxListen.unsubscribe(tpc)
 
       check(testDmp[0][0] == "tx> Subscribe(02):")
       check(testDmp[1][0] == "rx> SubAck(00):") # and testDmp[1][1] == "00 01 00 ")
@@ -34,6 +35,7 @@ suite "test suite for subscribe":
       await sleepAsync 500
       await ctxMain.publish(tpc, msg, 1)
       await sleepAsync 500
+      await ctxListen.unsubscribe(tpc)
 
       check(testDmp[0][0] == "tx> Subscribe(02):")
       check(testDmp[1][0] == "rx> SubAck(00):" and testDmp[1][1] == "00 02 01 ") # and testDmp[1][1] == "00 01 01 ")
@@ -44,7 +46,7 @@ suite "test suite for subscribe":
 
     waitFor conn()
 
-  
+
   test "subscribe to topic qos=2":
     let (tpc, msg) = tdata("subscribe to topic qos=2")
 
@@ -57,6 +59,7 @@ suite "test suite for subscribe":
       await sleepAsync 500
       await ctxMain.publish(tpc, msg, 2)
       await sleepAsync 500
+      await ctxListen.unsubscribe(tpc)
 
       check(testDmp[0][0] == "tx> Subscribe(02):")
       check(testDmp[1][0] == "rx> SubAck(00):" and testDmp[1][1] == "00 03 02 ") # and testDmp[1][1] == "00 01 02 ")
@@ -65,8 +68,9 @@ suite "test suite for subscribe":
       check(testDmp[4][0] == "tx> PubRel(02):" and testDmp[4][1] == "00 03 ") # and testDmp[4][1] == "00 01 ")
       check(testDmp[5][0] == "rx> PubComp(00):" and testDmp[5][1] == "00 03 ") # and testDmp[5][1] == "00 01 ")
       check(testDmp[6][0] == "rx> Publish(04):")
-      check(testDmp[7][0] == "tx> PubRel(02):" and testDmp[7][1] == "00 02 ") # and testDmp[7][1] == "00 01 ")
-      check(testDmp[8][0] == "rx> PubComp(00):" and testDmp[8][1] == "00 02 ") # and testDmp[8][1] == "00 01 ")
+      check(testDmp[7][0] == "tx> PubRec(02):" and testDmp[7][1] == "00 02 ") # and testDmp[7][1] == "00 01 ")
+      check(testDmp[8][0] == "rx> PubRel(02):" and testDmp[8][1] == "00 02 ") # and testDmp[8][1] == "00 01 ")
+      check(testDmp[9][0] == "tx> PubComp(02):" and testDmp[9][1] == "00 02 ")
 
     waitFor conn()
 

--- a/test/subscribe.nim
+++ b/test/subscribe.nim
@@ -5,16 +5,16 @@ suite "test suite for subscribe":
     let (tpc, msg) = tdata("subscribe to topic qos=0")
 
     proc conn() {.async.} =
-      proc on_data(topic: string, message: string) =
+      proc on_data_sub_qos0(topic: string, message: string) =
         if topic == tpc:
           check(message == msg)
           return
-      await ctxListen.subscribe(tpc, 0, on_data)
+      await ctxListen.subscribe(tpc, 0, on_data_sub_qos0)
       await sleepAsync 500
       await ctxMain.publish(tpc, msg, 0)
       await sleepAsync 500
       await ctxListen.unsubscribe(tpc)
-
+      await sleepAsync 500
       check(testDmp[0][0] == "tx> Subscribe(02):")
       check(testDmp[1][0] == "rx> SubAck(00):") # and testDmp[1][1] == "00 01 00 ")
       check(testDmp[2][0] == "tx> Publish(00):")
@@ -27,22 +27,22 @@ suite "test suite for subscribe":
     let (tpc, msg) = tdata("subscribe to topic qos=1")
 
     proc conn() {.async.} =
-      proc on_data(topic: string, message: string) =
+      proc on_data_sub_qos1(topic: string, message: string) =
         if topic == tpc:
           check(message == msg)
           return
-      await ctxListen.subscribe(tpc, 1, on_data)
+      await ctxListen.subscribe(tpc, 1, on_data_sub_qos1)
       await sleepAsync 500
       await ctxMain.publish(tpc, msg, 1)
       await sleepAsync 500
       await ctxListen.unsubscribe(tpc)
-
+      await sleepAsync 500
       check(testDmp[0][0] == "tx> Subscribe(02):")
-      check(testDmp[1][0] == "rx> SubAck(00):" and testDmp[1][1] == "00 02 01 ") # and testDmp[1][1] == "00 01 01 ")
+      check(testDmp[1][0] == "rx> SubAck(00):") # and testDmp[1][1] == "00 02 01 ") # and testDmp[1][1] == "00 01 01 ")
       check(testDmp[2][0] == "tx> Publish(02):")
-      check(testDmp[3][0] == "rx> PubAck(00):" and testDmp[3][1] == "00 02 ") # and testDmp[3][1] == "00 01 ")
+      check(testDmp[3][0] == "rx> PubAck(00):") # and testDmp[3][1] == "00 02 ") # and testDmp[3][1] == "00 01 ")
       check(testDmp[4][0] == "rx> Publish(02):")
-      check(testDmp[5][0] == "tx> PubAck(02):" and testDmp[5][1] == "00 01 ") # and testDmp[5][1] == "00 01 ")
+      check(testDmp[5][0] == "tx> PubAck(02):") # and testDmp[5][1] == "00 01 ") # and testDmp[5][1] == "00 01 ")
 
     waitFor conn()
 
@@ -51,26 +51,117 @@ suite "test suite for subscribe":
     let (tpc, msg) = tdata("subscribe to topic qos=2")
 
     proc conn() {.async.} =
-      proc on_data(topic: string, message: string) =
+      proc on_data_sub_qos2(topic: string, message: string) =
         if topic == tpc:
           check(message == msg)
           return
-      await ctxListen.subscribe(tpc, 2, on_data)
+      await ctxListen.subscribe(tpc, 2, on_data_sub_qos2)
       await sleepAsync 500
       await ctxMain.publish(tpc, msg, 2)
       await sleepAsync 500
       await ctxListen.unsubscribe(tpc)
-
+      await sleepAsync 500
       check(testDmp[0][0] == "tx> Subscribe(02):")
-      check(testDmp[1][0] == "rx> SubAck(00):" and testDmp[1][1] == "00 03 02 ") # and testDmp[1][1] == "00 01 02 ")
+      check(testDmp[1][0] == "rx> SubAck(00):") # and testDmp[1][1] == "00 03 02 ") # and testDmp[1][1] == "00 01 02 ")
       check(testDmp[2][0] == "tx> Publish(04):")
-      check(testDmp[3][0] == "rx> PubRec(00):" and testDmp[3][1] == "00 03 ") # and testDmp[3][1] == "00 01 ")
-      check(testDmp[4][0] == "tx> PubRel(02):" and testDmp[4][1] == "00 03 ") # and testDmp[4][1] == "00 01 ")
-      check(testDmp[5][0] == "rx> PubComp(00):" and testDmp[5][1] == "00 03 ") # and testDmp[5][1] == "00 01 ")
+      check(testDmp[3][0] == "rx> PubRec(00):") # and testDmp[3][1] == "00 03 ") # and testDmp[3][1] == "00 01 ")
+      check(testDmp[4][0] == "tx> PubRel(02):") # and testDmp[4][1] == "00 03 ") # and testDmp[4][1] == "00 01 ")
+      check(testDmp[5][0] == "rx> PubComp(00):") # and testDmp[5][1] == "00 03 ") # and testDmp[5][1] == "00 01 ")
       check(testDmp[6][0] == "rx> Publish(04):")
-      check(testDmp[7][0] == "tx> PubRec(02):" and testDmp[7][1] == "00 02 ") # and testDmp[7][1] == "00 01 ")
-      check(testDmp[8][0] == "rx> PubRel(02):" and testDmp[8][1] == "00 02 ") # and testDmp[8][1] == "00 01 ")
-      check(testDmp[9][0] == "tx> PubComp(02):" and testDmp[9][1] == "00 02 ")
+      check(testDmp[7][0] == "tx> PubRec(02):") # and testDmp[7][1] == "00 02 ") # and testDmp[7][1] == "00 01 ")
+      check(testDmp[8][0] == "rx> PubRel(02):") # and testDmp[8][1] == "00 02 ") # and testDmp[8][1] == "00 01 ")
+      check(testDmp[9][0] == "tx> PubComp(02):") # and testDmp[9][1] == "00 02 ")
+
+    waitFor conn()
+
+
+  test "subscribe to multiple topics":
+    let (tpc, msg) = tdata("subscribe to multiple topics")
+
+    proc conn() {.async.} =
+      var
+        topic1: bool
+        topic2: bool
+
+      proc on_data_sub_mul1(topic: string, message: string) =
+        check(message == msg & "-mul1")
+        if topic1 == true:
+          topic1 = false
+        else:
+          topic1 = true
+
+      proc on_data_sub_mul2(topic: string, message: string) =
+        check(message == msg & "-mul2")
+        if topic2 == true:
+          topic2 = false
+        else:
+          topic2 = true
+
+      await ctxListen.subscribe(tpc & "-1", 0, on_data_sub_mul1)
+      await ctxListen.subscribe(tpc & "-2", 0, on_data_sub_mul2)
+      await sleepAsync 500
+      await ctxMain.publish(tpc & "-1", msg & "-mul1", 0)
+      await ctxMain.publish(tpc & "-2", msg & "-mul2", 0)
+      await sleepAsync 500
+      await ctxListen.unsubscribe(tpc & "-1")
+      await ctxListen.unsubscribe(tpc & "-2")
+      await sleepAsync 500
+      check(topic1 == true)
+      check(topic2 == true)
+
+    waitFor conn()
+
+
+  test "subscribe to multiple with identical topic":
+    let (tpc, msg) = tdata("subscribe to multiple with identical topic")
+
+    proc conn() {.async.} =
+      var
+        sub1: int
+        sub2: int
+        sub3: int
+
+      proc on_data_sub_mul1(topic: string, message: string) =
+        if topic == tpc:
+          sub1 += 1
+
+      proc on_data_sub_mul2(topic: string, message: string) =
+        if topic == tpc:
+          sub2 += 1
+
+      proc on_data_sub_mul3(topic: string, message: string) =
+        if topic == tpc:
+          sub3 += 1
+
+      check(ctxListen.pubCallbacks.len() == 0)
+
+      # Add 1 msg to sub1
+      await ctxListen.subscribe(tpc, 0, on_data_sub_mul1)
+      await ctxMain.publish(tpc, msg, 0)
+
+      check(ctxListen.pubCallbacks.len() == 1)
+      await sleepAsync 500
+
+      await ctxListen.subscribe(tpc, 0, on_data_sub_mul2)
+
+      # sub3 now overrides sub1 and sub2
+      await ctxListen.subscribe(tpc, 0, on_data_sub_mul3)
+
+      check(ctxListen.pubCallbacks.len() == 1)
+
+      await sleepAsync 500
+      await ctxMain.publish(tpc, msg, 0)
+      await ctxMain.publish(tpc, msg, 0)
+      await ctxMain.publish(tpc, msg, 0)
+      await sleepAsync 500
+
+      await ctxListen.unsubscribe(tpc)
+      check(ctxListen.pubCallbacks.len() == 0)
+
+      check(sub1 == 1)
+      check(sub2 == 0)
+      check(sub3 == 3)
+      await sleepAsync 500
 
     waitFor conn()
 

--- a/test/subscribe.nim
+++ b/test/subscribe.nim
@@ -1,17 +1,47 @@
 
 suite "test suite for subscribe":
 
-  test "subscribe to topic":
-    let (tpc, msg) = tdata("subscribe to topic")
+  test "subscribe to topic qos=0":
+    let (tpc, msg) = tdata("subscribe to topic qos=1")
 
     proc conn() {.async.} =
       proc on_data(topic: string, message: string) =
         if topic == tpc:
           check(message == msg)
           return
+      await ctxListen.subscribe(tpc, 0, on_data)
+      await sleepAsync 500
+      await ctxMain.publish(tpc, msg, 0)
 
-      await ctxMain.subscribe(tpc, 2, on_data)
+    waitFor conn()
+
+
+  test "subscribe to topic qos=1":
+    let (tpc, msg) = tdata("subscribe to topic qos=1")
+
+    proc conn() {.async.} =
+      proc on_data(topic: string, message: string) =
+        if topic == tpc:
+          check(message == msg)
+          return
+      await ctxListen.subscribe(tpc, 1, on_data)
+      await sleepAsync 500
       await ctxMain.publish(tpc, msg, 1)
+
+    waitFor conn()
+
+  
+  test "subscribe to topic qos=2":
+    let (tpc, msg) = tdata("subscribe to topic qos=2")
+
+    proc conn() {.async.} =
+      proc on_data(topic: string, message: string) =
+        if topic == tpc:
+          check(message == msg)
+          return
+      await ctxListen.subscribe(tpc, 2, on_data)
+      await sleepAsync 500
+      await ctxMain.publish(tpc, msg, 2)
 
     waitFor conn()
 

--- a/test/subscribe.nim
+++ b/test/subscribe.nim
@@ -12,6 +12,12 @@ suite "test suite for subscribe":
       await ctxListen.subscribe(tpc, 0, on_data)
       await sleepAsync 500
       await ctxMain.publish(tpc, msg, 0)
+      await sleepAsync 500
+
+      check(testDmp[0][0] == "tx> Subscribe(02):")
+      check(testDmp[1][0] == "rx> SubAck(00):" and testDmp[1][1] == "00 01 00 ")
+      check(testDmp[2][0] == "tx> Publish(00):")
+      check(testDmp[3][0] == "rx> Publish(00):")
 
     waitFor conn()
 
@@ -29,6 +35,13 @@ suite "test suite for subscribe":
       await ctxMain.publish(tpc, msg, 1)
       await sleepAsync 500
 
+      check(testDmp[0][0] == "tx> Subscribe(02):")
+      check(testDmp[1][0] == "rx> SubAck(00):" and testDmp[1][1] == "00 01 01 ")
+      check(testDmp[2][0] == "tx> Publish(02):")
+      check(testDmp[3][0] == "rx> PubAck(00):" and testDmp[3][1] == "00 01 ")
+      check(testDmp[4][0] == "rx> Publish(02):")
+      check(testDmp[5][0] == "tx> PubAck(02):" and testDmp[5][1] == "00 01 ")
+
     waitFor conn()
 
   
@@ -44,6 +57,16 @@ suite "test suite for subscribe":
       await sleepAsync 500
       await ctxMain.publish(tpc, msg, 2)
       await sleepAsync 500
+
+      check(testDmp[0][0] == "tx> Subscribe(02):")
+      check(testDmp[1][0] == "rx> SubAck(00):" and testDmp[1][1] == "00 01 02 ")
+      check(testDmp[2][0] == "tx> Publish(04):")
+      check(testDmp[3][0] == "rx> PubRec(00):" and testDmp[3][1] == "00 01 ")
+      check(testDmp[4][0] == "tx> PubRel(02):" and testDmp[4][1] == "00 01 ")
+      check(testDmp[5][0] == "rx> PubComp(00):" and testDmp[5][1] == "00 01 ")
+      check(testDmp[6][0] == "rx> Publish(04):")
+      check(testDmp[7][0] == "tx> PubRel(02):" and testDmp[7][1] == "00 01 ")
+      check(testDmp[8][0] == "rx> PubComp(00):" and testDmp[8][1] == "00 01 ")
 
     waitFor conn()
 

--- a/test/subscribe.nim
+++ b/test/subscribe.nim
@@ -15,7 +15,7 @@ suite "test suite for subscribe":
       await sleepAsync 500
 
       check(testDmp[0][0] == "tx> Subscribe(02):")
-      check(testDmp[1][0] == "rx> SubAck(00):" and testDmp[1][1] == "00 01 00 ")
+      check(testDmp[1][0] == "rx> SubAck(00):") # and testDmp[1][1] == "00 01 00 ")
       check(testDmp[2][0] == "tx> Publish(00):")
       check(testDmp[3][0] == "rx> Publish(00):")
 
@@ -36,11 +36,11 @@ suite "test suite for subscribe":
       await sleepAsync 500
 
       check(testDmp[0][0] == "tx> Subscribe(02):")
-      check(testDmp[1][0] == "rx> SubAck(00):" and testDmp[1][1] == "00 01 01 ")
+      check(testDmp[1][0] == "rx> SubAck(00):" and testDmp[1][1] == "00 02 01 ") # and testDmp[1][1] == "00 01 01 ")
       check(testDmp[2][0] == "tx> Publish(02):")
-      check(testDmp[3][0] == "rx> PubAck(00):" and testDmp[3][1] == "00 01 ")
+      check(testDmp[3][0] == "rx> PubAck(00):" and testDmp[3][1] == "00 02 ") # and testDmp[3][1] == "00 01 ")
       check(testDmp[4][0] == "rx> Publish(02):")
-      check(testDmp[5][0] == "tx> PubAck(02):" and testDmp[5][1] == "00 01 ")
+      check(testDmp[5][0] == "tx> PubAck(02):" and testDmp[5][1] == "00 01 ") # and testDmp[5][1] == "00 01 ")
 
     waitFor conn()
 
@@ -59,14 +59,14 @@ suite "test suite for subscribe":
       await sleepAsync 500
 
       check(testDmp[0][0] == "tx> Subscribe(02):")
-      check(testDmp[1][0] == "rx> SubAck(00):" and testDmp[1][1] == "00 01 02 ")
+      check(testDmp[1][0] == "rx> SubAck(00):" and testDmp[1][1] == "00 03 02 ") # and testDmp[1][1] == "00 01 02 ")
       check(testDmp[2][0] == "tx> Publish(04):")
-      check(testDmp[3][0] == "rx> PubRec(00):" and testDmp[3][1] == "00 01 ")
-      check(testDmp[4][0] == "tx> PubRel(02):" and testDmp[4][1] == "00 01 ")
-      check(testDmp[5][0] == "rx> PubComp(00):" and testDmp[5][1] == "00 01 ")
+      check(testDmp[3][0] == "rx> PubRec(00):" and testDmp[3][1] == "00 03 ") # and testDmp[3][1] == "00 01 ")
+      check(testDmp[4][0] == "tx> PubRel(02):" and testDmp[4][1] == "00 03 ") # and testDmp[4][1] == "00 01 ")
+      check(testDmp[5][0] == "rx> PubComp(00):" and testDmp[5][1] == "00 03 ") # and testDmp[5][1] == "00 01 ")
       check(testDmp[6][0] == "rx> Publish(04):")
-      check(testDmp[7][0] == "tx> PubRel(02):" and testDmp[7][1] == "00 01 ")
-      check(testDmp[8][0] == "rx> PubComp(00):" and testDmp[8][1] == "00 01 ")
+      check(testDmp[7][0] == "tx> PubRel(02):" and testDmp[7][1] == "00 02 ") # and testDmp[7][1] == "00 01 ")
+      check(testDmp[8][0] == "rx> PubComp(00):" and testDmp[8][1] == "00 02 ") # and testDmp[8][1] == "00 01 ")
 
     waitFor conn()
 

--- a/test/subscribe.nim
+++ b/test/subscribe.nim
@@ -187,3 +187,232 @@ suite "test suite for subscribe":
     waitFor conn()
 
 
+  test "stay subscribed after disconnect with reconnect":
+    let (tpc, msg) = tdata("stay subscribed after disconnect with reconnect")
+
+    proc conn() {.async.} =
+      await ctxSlave.start()
+      await sleepAsync(1000)
+      testDmp = @[]
+
+      var msgCount: int
+      proc on_data_sub_keep(topic: string, message: string) =
+        msgCount += 1
+
+      await ctxSlave.subscribe(tpc, 0, on_data_sub_keep)
+      await sleepAsync 500
+      await ctxMain.publish(tpc, msg, 0) # msg 1
+      await sleepAsync 500
+
+      # Disconnect
+      ctxSlave.state = Disconnecting
+      ctxSlave.s.close()
+      await sleepAsync(500)
+      ctxSlave.state = Disconnected
+      await sleepAsync(2000) # Auto-reconnect loop is 1000ms, wait 2000ms to ensure loop
+      # We should automatic reconnect here
+
+      await ctxMain.publish(tpc, msg, 0) # msg 2
+      await ctxMain.publish(tpc, msg, 0) # msg 3
+      await sleepAsync 500
+      await ctxSlave.unsubscribe(tpc)
+      await sleepAsync 500
+
+      check(msgCount == 3) # A total of 3 msgs on this topic
+      check(testDmp[0][0] == "tx> Subscribe(02):")
+      check(testDmp[1][0] == "rx> SubAck(00):")
+      check(testDmp[2][0] == "tx> Publish(00):")
+      check(testDmp[3][0] == "rx> Publish(00):")
+      # Disconnected
+      check(testDmp[4][0] == "tx> Connect(00):")
+      check(testDmp[5][0] == "rx> ConnAck(00):")
+      # Re-subscribe
+      check(testDmp[6][0] == "tx> Subscribe(02):")
+      check(testDmp[7][0] == "rx> SubAck(00):")
+      check(testDmp[8][0] == "tx> Publish(00):")
+      check(testDmp[9][0] == "tx> Publish(00):")
+      check(testDmp[10][0] == "rx> Publish(00):")
+      check(testDmp[11][0] == "rx> Publish(00):")
+      # Unsub
+      check(testDmp[12][0] == "tx> Unsubscribe(02):")
+      check(testDmp[13][0] == "rx> Unsuback(00):")
+
+    waitFor conn()
+
+
+  test "stay subscribed after multipe (2) disconnect with reconnect":
+    let (tpc, msg) = tdata("stay subscribed after multipe (2) disconnect with reconnect")
+
+    proc conn() {.async.} =
+      await ctxSlave.start()
+      await sleepAsync(1000)
+      testDmp = @[]
+
+      var msgCount: int
+      proc on_data_sub_keep_multiple(topic: string, message: string) =
+        msgCount += 1
+
+      await ctxSlave.subscribe(tpc, 0, on_data_sub_keep_multiple)
+      await sleepAsync 500
+      await ctxMain.publish(tpc, msg, 0) # msg 1
+      await sleepAsync 500
+
+      # Disconnect 1/2
+      ctxSlave.state = Disconnecting
+      ctxSlave.s.close()
+      await sleepAsync(500)
+      ctxSlave.state = Disconnected
+      await sleepAsync(2000) # Auto-reconnect loop is 1000ms, wait 2000ms to ensure loop
+      # We should automatic reconnect here
+
+      # Disconnect 2/2
+      ctxSlave.state = Disconnecting
+      ctxSlave.s.close()
+      await sleepAsync(500)
+      ctxSlave.state = Disconnected
+      await sleepAsync(2000) # Auto-reconnect loop is 1000ms, wait 2000ms to ensure loop
+      # We should automatic reconnect here
+
+      await ctxMain.publish(tpc, msg, 0) # msg 2
+      await ctxMain.publish(tpc, msg, 0) # msg 3
+      await sleepAsync 500
+      await ctxSlave.unsubscribe(tpc)
+      await sleepAsync 500
+
+      check(msgCount == 3) # A total of 3 msgs on this topic
+      check(testDmp[0][0] == "tx> Subscribe(02):")
+      check(testDmp[1][0] == "rx> SubAck(00):")
+      check(testDmp[2][0] == "tx> Publish(00):")
+      check(testDmp[3][0] == "rx> Publish(00):")
+
+      # Disconnected 1/2
+      check(testDmp[4][0] == "tx> Connect(00):")
+      check(testDmp[5][0] == "rx> ConnAck(00):")
+      # Re-subscribe
+      check(testDmp[6][0] == "tx> Subscribe(02):")
+      check(testDmp[7][0] == "rx> SubAck(00):")
+
+      # Disconnected 1/2
+      check(testDmp[8][0] == "tx> Connect(00):")
+      check(testDmp[9][0] == "rx> ConnAck(00):")
+      # Re-subscribe
+      check(testDmp[10][0] == "tx> Subscribe(02):")
+      check(testDmp[11][0] == "rx> SubAck(00):")
+
+      check(testDmp[12][0] == "tx> Publish(00):")
+      check(testDmp[13][0] == "tx> Publish(00):")
+      check(testDmp[14][0] == "rx> Publish(00):")
+      check(testDmp[15][0] == "rx> Publish(00):")
+      # Unsub
+      check(testDmp[16][0] == "tx> Unsubscribe(02):")
+      check(testDmp[17][0] == "rx> Unsuback(00):")
+
+      await ctxSlave.disconnect()
+      await sleepAsync(1000)
+
+    waitFor conn()
+
+
+  test "stay subscribed after long disconnect with reconnect":
+    ## This test currently needs manual actions - you need to close/disconnect
+    ## your broker during the test and open/reconnect.
+
+    echo "\n\nTHIS TEST NEEDS MANUAL ACTIONS - STAY READY\n\n"
+
+    let (tpc, msg) = tdata("stay subscribed after long disconnect with reconnect")
+
+    proc conn() {.async.} =
+      # Disconnect main clients to avoid interference with result
+      await sleepAsync(1000)
+      waitFor ctxMain.disconnect()
+      waitFor ctxListen.disconnect()
+      await sleepAsync(1000)
+
+      await ctxSlave.start()
+      ctxSlave.set_ping_interval(90) # Increas ping to avoid interference with package order
+      await sleepAsync(1000)
+      testDmp = @[]
+
+      var msgCount: int
+      proc on_data_sub_keep_long(topic: string, message: string) =
+        msgCount += 1
+
+      await ctxSlave.subscribe(tpc, 0, on_data_sub_keep_long)
+      await sleepAsync 500
+      await ctxSlave.publish(tpc, msg, 0) # msg 1
+      await sleepAsync 500
+
+      # Disconnect
+      echo "\n\nDISCONNECT THE BROKER NOW\n\n"
+      await sleepAsync(2000)
+
+      # Publish messages while the broker is down
+      await ctxSlave.publish(tpc, msg, 0) # msg 2
+      await ctxSlave.publish(tpc, msg, 0) # msg 3
+      await ctxSlave.publish(tpc, msg, 0) # msg 4
+      await ctxSlave.publish(tpc, msg, 0) # msg 5
+      await sleepAsync(5000)
+
+      # Reconnect the broker
+      echo "\n\nCONNECT THE BROKER NOW\n\n"
+      await sleepAsync(4000)
+
+      # Send messages when the broker is up again
+      await ctxSlave.publish(tpc, msg, 0) # msg 2
+      await ctxSlave.publish(tpc, msg, 0) # msg 3
+      await sleepAsync 1500
+      await ctxSlave.unsubscribe(tpc)
+      await sleepAsync 500
+
+      check(msgCount == 7)
+
+      # Connect and send 1 messages
+      check(testDmp[0][0] == "tx> Subscribe(02):")
+      check(testDmp[1][0] == "rx> SubAck(00):")
+      check(testDmp[2][0] == "tx> Publish(00):")
+      check(testDmp[3][0] == "rx> Publish(00):")
+
+      # Manual disconnect
+      check(testDmp[4][0] == "tx> Disconnect(00):")
+
+      # Connect
+      check(testDmp[5][0] == "tx> Connect(00):")
+      check(testDmp[6][0] == "rx> ConnAck(00):")
+
+      # Re-subscribe
+      check(testDmp[7][0] == "tx> Subscribe(02):")
+
+      # Publish all messages in queue
+      check(testDmp[8][0] == "tx> Publish(00):")
+      check(testDmp[9][0] == "tx> Publish(00):")
+      check(testDmp[10][0] == "tx> Publish(00):")
+      check(testDmp[11][0] == "tx> Publish(00):")
+
+      # Receive subscribe ack
+      check(testDmp[12][0] == "rx> SubAck(00):")
+
+      # Receive all messages
+      check(testDmp[13][0] == "rx> Publish(00):")
+      check(testDmp[14][0] == "rx> Publish(00):")
+      check(testDmp[15][0] == "rx> Publish(00):")
+      check(testDmp[16][0] == "rx> Publish(00):")
+
+      # Publish the 2 last messages
+      check(testDmp[17][0] == "tx> Publish(00):")
+      check(testDmp[18][0] == "tx> Publish(00):")
+
+      # Receive the 2 last messages
+      check(testDmp[19][0] == "rx> Publish(00):")
+      check(testDmp[20][0] == "rx> Publish(00):")
+
+      # Unsub
+      check(testDmp[21][0] == "tx> Unsubscribe(02):")
+      check(testDmp[22][0] == "rx> Unsuback(00):")
+
+      # Reconnect main clients
+      await ctxSlave.disconnect()
+      await ctxMain.start()
+      await ctxListen.start()
+      await sleepAsync(1000)
+
+    waitFor conn()

--- a/test/subscribe.nim
+++ b/test/subscribe.nim
@@ -166,3 +166,24 @@ suite "test suite for subscribe":
     waitFor conn()
 
 
+  test "subscribe to #":
+    let (_, msg) = tdata("subscribe to #")
+
+    proc conn() {.async.} =
+      var msgCount: int
+      proc on_data_sub_all(topic: string, message: string) =
+        msgCount += 1
+
+      await ctxListen.subscribe("#", 0, on_data_sub_all)
+      await sleepAsync 500
+      await ctxMain.publish("random1", msg, 0)
+      await ctxMain.publish("random2", msg, 0)
+      await ctxMain.publish("random3", msg, 0)
+      await sleepAsync 500
+      await ctxListen.unsubscribe("#")
+      await sleepAsync 500
+      check(msgCount == 3)
+
+    waitFor conn()
+
+

--- a/test/subscribe.nim
+++ b/test/subscribe.nim
@@ -27,6 +27,7 @@ suite "test suite for subscribe":
       await ctxListen.subscribe(tpc, 1, on_data)
       await sleepAsync 500
       await ctxMain.publish(tpc, msg, 1)
+      await sleepAsync 500
 
     waitFor conn()
 
@@ -42,6 +43,7 @@ suite "test suite for subscribe":
       await ctxListen.subscribe(tpc, 2, on_data)
       await sleepAsync 500
       await ctxMain.publish(tpc, msg, 2)
+      await sleepAsync 500
 
     waitFor conn()
 

--- a/test/tester.nim
+++ b/test/tester.nim
@@ -42,10 +42,10 @@ proc tdata(t: string): (string, string) =
   tout(topicTest, msg, t)
   return (topicTest, msg)
 
-#include "connection.nim"
+include "connection.nim"
 include "subscribe.nim"
-#include "publish_retained.nim"
-#include "publish_qos.nim"
+include "publish_retained.nim"
+include "publish_qos.nim"
 
 waitFor ctxMain.disconnect()
 waitFor ctxListen.disconnect()

--- a/test/tester.nim
+++ b/test/tester.nim
@@ -12,6 +12,7 @@ randomize()
 let ctxMain = newMqttCtx("nmqttTestMain")
 #ctxMain.set_host("test.mosquitto.org", 1883)
 ctxMain.set_host("127.0.0.1", 1883)
+ctxMain.set_ping_interval(120)
 waitFor ctxMain.start()
 
 # Test clíent slave:
@@ -20,6 +21,15 @@ waitFor ctxMain.start()
 let ctxSlave = newMqttCtx("nmqttTestSlave")
 #ctxSlave.set_host("test.mosquitto.org", 1883)
 ctxSlave.set_host("127.0.0.1", 1883)
+
+# Test clíent listen:
+# ctxListen is a client which only should be used to make subscribe
+# callbacks. Do not close it.
+let ctxListen = newMqttCtx("nmqttTestListen")
+#ctxSlave.set_host("test.mosquitto.org", 1883)
+ctxListen.set_host("127.0.0.1", 1883)
+ctxMain.set_ping_interval(120)
+waitFor ctxListen.start()
 
 proc tout(t, m, s: string) =
   ## Print test data during test.

--- a/test/tester.nim
+++ b/test/tester.nim
@@ -47,6 +47,8 @@ proc tdata(t: string): (string, string) =
   testDmp = @[]
   return (topicTest, msg)
 
+waitFor sleepAsync(1500) # Let the clients connect
+
 include "connection.nim"
 include "subscribe.nim"
 include "unsubscribe.nim"

--- a/test/tester.nim
+++ b/test/tester.nim
@@ -45,7 +45,7 @@ proc tdata(t: string): (string, string) =
   testDmp = @[]
   return (topicTest, msg)
 
-include "connection.nim"
+#include "connection.nim"
 include "subscribe.nim"
 include "publish_retained.nim"
 include "publish_qos.nim"

--- a/test/tester.nim
+++ b/test/tester.nim
@@ -2,6 +2,8 @@
 
 import asyncdispatch, unittest, oids, random
 
+var testDmp: seq[seq[string]]
+
 include ../src/nmqtt
 
 randomize()
@@ -40,6 +42,7 @@ proc tdata(t: string): (string, string) =
   let topicTest = $genOid()
   let msg = $rand(99999999)
   tout(topicTest, msg, t)
+  testDmp = @[]
   return (topicTest, msg)
 
 include "connection.nim"

--- a/test/tester.nim
+++ b/test/tester.nim
@@ -4,6 +4,10 @@ import asyncdispatch, unittest, oids, random
 
 var testDmp: seq[seq[string]]
 
+when not defined(test):
+  echo "Please run with -d:test, exiting"
+  quit()
+
 include ../src/nmqtt
 
 randomize()
@@ -45,8 +49,9 @@ proc tdata(t: string): (string, string) =
   testDmp = @[]
   return (topicTest, msg)
 
-#include "connection.nim"
+include "connection.nim"
 include "subscribe.nim"
+include "unsubscribe.nim"
 include "publish_retained.nim"
 include "publish_qos.nim"
 

--- a/test/tester.nim
+++ b/test/tester.nim
@@ -42,9 +42,10 @@ proc tdata(t: string): (string, string) =
   tout(topicTest, msg, t)
   return (topicTest, msg)
 
-include "connection.nim"
+#include "connection.nim"
 include "subscribe.nim"
-include "publish_retained.nim"
-include "publish_qos.nim"
+#include "publish_retained.nim"
+#include "publish_qos.nim"
 
 waitFor ctxMain.disconnect()
+waitFor ctxListen.disconnect()

--- a/test/tester.nim
+++ b/test/tester.nim
@@ -1,5 +1,3 @@
-# Copyright 2020 - Thomas T. Jarløv
-
 import asyncdispatch, unittest, oids, random
 
 var testDmp: seq[seq[string]]
@@ -52,8 +50,11 @@ proc tdata(t: string): (string, string) =
 include "connection.nim"
 include "subscribe.nim"
 include "unsubscribe.nim"
+include "publish.nim"
 include "publish_retained.nim"
 include "publish_qos.nim"
+include "ping.nim"
+include "utils.nim"
 
 waitFor ctxMain.disconnect()
 waitFor ctxListen.disconnect()

--- a/test/unsubscribe.nim
+++ b/test/unsubscribe.nim
@@ -1,0 +1,77 @@
+suite "test suite for unsubscribe":
+
+  test "unsubscribe from topic":
+    let (tpc, msg) = tdata("unsubscribe from topic")
+
+    proc conn() {.async.} =
+      proc on_data_unsub(topic: string, message: string) =
+        if topic == tpc:
+          check(message == msg)
+          return
+
+      check(ctxListen.pubCallbacks.len() == 0)
+
+      await ctxListen.subscribe(tpc, 0, on_data_unsub)
+
+      check(ctxListen.pubCallbacks.len() == 1)
+
+      await sleepAsync 500
+      await ctxMain.publish(tpc, msg, 0)
+      await sleepAsync 500
+      await ctxListen.unsubscribe(tpc)
+
+      check(ctxListen.pubCallbacks.len() == 0)
+
+      await sleepAsync 500
+      await ctxMain.publish(tpc, "Msg must not be received", 0)
+      await sleepAsync 500
+
+      check(testDmp[0][0] == "tx> Subscribe(02):")
+      check(testDmp[1][0] == "rx> SubAck(00):") # and testDmp[1][1] == "00 01 00 ")
+      check(testDmp[2][0] == "tx> Publish(00):")
+      check(testDmp[3][0] == "rx> Publish(00):")
+      check(testDmp[4][0] == "tx> Unsubscribe(02):")
+      check(testDmp[5][0] == "rx> Unsuback(00):")
+      check(testDmp[6][0] == "tx> Publish(00):")
+      check(testDmp.len() == 7)
+
+    waitFor conn()
+
+
+  test "unsubscribe from one of many topics":
+    let (tpc, msg) = tdata("unsubscribe from one of many topics")
+
+    proc conn() {.async.} =
+      var
+        topic2: bool
+
+      proc on_data_unsub1(topic: string, message: string) =
+        check(message == msg)
+
+      proc on_data_unsub2(topic: string, message: string) =
+        check(message == msg)
+        topic2 = true
+
+      check(ctxListen.pubCallbacks.len() == 0)
+
+      await ctxListen.subscribe(tpc & "-1", 0, on_data_unsub1)
+      await ctxListen.subscribe(tpc & "-2", 0, on_data_unsub2)
+
+      check(ctxListen.pubCallbacks.len() == 2)
+
+      await sleepAsync 500
+      await ctxListen.unsubscribe(tpc & "-2")
+
+      check(ctxListen.pubCallbacks.len() == 1)
+
+      await sleepAsync 500
+      await ctxMain.publish(tpc & "-1", msg, 0)
+      await ctxMain.publish(tpc & "-2", msg, 0)
+      await sleepAsync 500
+      await ctxListen.unsubscribe(tpc & "-1")
+
+      check(ctxListen.pubCallbacks.len() == 0)
+
+      check(topic2 == false)
+
+    waitFor conn()

--- a/test/utils.nim
+++ b/test/utils.nim
@@ -1,0 +1,22 @@
+
+suite "test suite for messages":
+
+  test "msgQueue() wait for all messages in workqueue":
+    let (tpc, msg) = tdata("msgQueue() wait for all messages in workqueue")
+
+    proc conn() {.async.} =
+
+      # Send msg with no delay
+      var msg: int
+      for i in 0 .. 10:
+        await ctxMain.publish(tpc, $msg, 2)
+        msg += 1
+        check(ctxMain.msgQueue > 0)
+
+      await sleepAsync(1000)
+      check(ctxMain.msgQueue == 0)
+
+      await ctxListen.unsubscribe(tpc)
+
+    waitFor conn()
+


### PR DESCRIPTION
This PR is based upon PR #21 .

## Goal
To create 2 binaries for Publishing and Subscribing. They can be seen as a simple replacement for `mosquitto_sub` and `mosquitto_pub`.

## Changes

* Nimble package has been changed to a hybrid package - the normal `nmqtt` library for import and 2 binary files.

* Added `nmqttsub` and `nmqttpub` to the repo

## Todo

* The option `--verbose` is currently not implemented.

* `nmqtt` still prints "Connecting xx", "Connected", etc. These stderr should comply with the cli-params.

* Is the names `nmqttsub` and `nmqttpub` good? Or should they follow mosquitto: `nmqtt_sub` and `nmqtt_pub`?

* Publish should be able:
  * To send a file
  * Keep tailing a file for changes
  * Send NULL values.

* Subscribe should be able to:
  * Output to file


## Output

### nmqttsub
```bash
$ ./nmqttsub --help
Subscribe to a topic on a MQTT-broker.

Usage:
  nmqttsub [options] -t {topic}
  nmqttsub [-h host -p port -u username -P password] -t {topic}

OPTIONS
  -?, --help                     print this cligen-erated help
  --help-syntax                  advanced: prepend,plurals,..
  -h=, --host=      "127.0.0.1"  IP-address of the broker. Defaults to localhost.
  -p=, --port=      1883         network port to connect too. Defaults to 1883 for plan MQTT and 8883 for MQTT
                                 with SSL.
  --ssl             false        enable ssl. Auto-enabled on port 8883.
  -c=, --clientid=  ""           your connection ID. Defaults to nmqtt_pub_ appended with processID.
  -u=, --username=  ""           provide a username
  -P=, --password=  ""           provide a password
  -t=, --topic=     REQUIRED     MQTT topic to publish to.
  -q=, --qos=       0            QOS: quality of service level to use for all messages. Defaults to 0.
  -v, --verbose     false        set verbose
```

### nmqttpub
```bash
$ ./nmqttpub --help
Publish MQTT messages to a MQTT-broker.

Usage:
  nmqttpub [options] -t {topic} -m {message}
  nmqttpub [-h host -p port -u username -P password] -t {topic} -m {message}

OPTIONS
  -?, --help                     print this cligen-erated help
  --help-syntax                  advanced: prepend,plurals,..
  -h=, --host=      "127.0.0.1"  IP-address of the broker. Defaults to localhost.
  -p=, --port=      1883         network port to connect too. Defaults to 1883 for plan MQTT and 8883 for MQTT
                                 with SSL.
  --ssl             false        enable ssl. Auto-enabled on port 8883.
  -c=, --clientid=  ""           your connection ID. Defaults to nmqtt_pub_ appended with processID.
  -u=, --username=  ""           provide a username
  -P=, --password=  ""           provide a password
  -t=, --topic=     REQUIRED     MQTT topic to publish to.
  -m=, --msg=       REQUIRED     set msg
  -q=, --qos=       0            QOS: quality of service level to use for all messages. Defaults to 0.
  -r, --retain      false        retain messages on the broker.
  -v, --verbose     false        set verbose
```