### PR TITLE
Will flags for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,23 @@ Usage:
   nmqtt_pub [-h host -p port -u username -P password] -t {topic} -m {message}
 
 OPTIONS
-  -?, --help                     print this cligen-erated help
-  --help-syntax                  advanced: prepend,plurals,..
-  -h=, --host=      "127.0.0.1"  IP-address of the broker.
-  -p=, --port=      1883         network port to connect too.
-  --ssl             false        enable ssl. Auto-enabled on port 8883.
-  -c=, --clientid=  ""           your connection ID. Defaults to nmqtt_pub_ appended with processID.
-  -u=, --username=  ""           provide a username
-  -P=, --password=  ""           provide a password
-  -t=, --topic=     REQUIRED     MQTT topic to publish to.
-  -m=, --msg=       REQUIRED     set msg
-  -q=, --qos=       0            quality of service level to use for all messages.
-  -r, --retain      false        retain messages on the broker.
-  -v, --verbose     false        set verbose
+  -?, --help        print this cligen-erated help
+  --help-syntax     advanced: prepend,plurals,..
+  -h=, --host=      IP-address of the broker.
+  -p=, --port=      network port to connect too.
+  --ssl             enable ssl. Auto-enabled on port 8883.
+  -c=, --clientid=  your connection ID. Defaults to nmqtt_pub_ appended with processID.
+  -u=, --username=  provide a username
+  -P=, --password=  provide a password
+  -t=, --topic=     MQTT topic to publish to.
+  -m=, --msg=       set msg
+  -q=, --qos=       quality of service level to use for all messages.
+  -r, --retain      retain messages on the broker.
+  --willtopic=      set the will's topic
+  --willmsg=        set the will's message
+  --willqos=        set the will's quality of service
+  --willretain      set to retain the will message
+  -v, --verbose     set verbose
 ```
 
 _`-verbose` not implemented yet_
@@ -68,17 +72,21 @@ Usage:
   nmqtt_sub [-h host -p port -u username -P password] -t {topic}
 
 OPTIONS
-  -?, --help                     print this cligen-erated help
-  --help-syntax                  advanced: prepend,plurals,..
-  -h=, --host=      "127.0.0.1"  IP-address of the broker.
-  -p=, --port=      1883         network port to connect too.
-  --ssl             false        enable ssl. Auto-enabled on port 8883.
-  -c=, --clientid=  ""           your connection ID. Defaults to nmqtt_pub_ appended with processID.
-  -u=, --username=  ""           provide a username
-  -P=, --password=  ""           provide a password
-  -t=, --topic=     REQUIRED     MQTT topic to publish to.
-  -q=, --qos=       0            quality of service level to use for all messages.
-  -v, --verbose     false        set verbose
+  -?, --help        print this cligen-erated help
+  --help-syntax     advanced: prepend,plurals,..
+  -h=, --host=      IP-address of the broker.
+  -p=, --port=      network port to connect too.
+  --ssl             enable ssl. Auto-enabled on port 8883.
+  -c=, --clientid=  your connection ID. Defaults to nmqtt_pub_ appended with processID.
+  -u=, --username=  provide a username
+  -P=, --password=  provide a password
+  -t=, --topic=     MQTT topic to publish to.
+  -q=, --qos=       quality of service level to use for all messages.
+  --willtopic=      set the will's topic
+  --willmsg=        set the will's message
+  --willqos=        set the will's quality of service
+  --willretain      set to retain the will message
+  -v, --verbose     set verbose
 ```
 
 _`-verbose` not implemented yet_
@@ -189,6 +197,17 @@ proc set_auth*(ctx: MqttCtx, username: string, password: string) =
 ```
 
 Set the authentication for the host
+
+
+____
+
+### set_will*
+
+```nim
+proc set_will*(ctx: MqttCtx, topic, msg: string, qos=0, retain=false) =
+```
+
+Set the clients will.
 
 
 ____

--- a/src/nmqtt_pub.nim
+++ b/src/nmqtt_pub.nim
@@ -4,10 +4,16 @@ from os import getCurrentProcessId
 include "nmqtt.nim"
 
 
-proc nmqttPub(host="127.0.0.1", port: int=1883, ssl:bool=false, clientid="", username="", password="", topic, msg: string, qos=0, retain=false, verbose=false) =
+proc nmqttPub(host="127.0.0.1", port: int=1883, ssl:bool=false, clientid="", username="", password="", topic, msg: string, qos=0, retain=false, willtopic="", willmsg="", willqos=0, willretain=false, verbose=false) =
   ## CLI tool for publish
   let ctx = newMqttCtx(if clientid != "": clientid else: "nmqtt_pub_" & $getCurrentProcessId())
   ctx.set_host(host, port, ssl)
+
+  if willretain and (willtopic == "" or willmsg == ""):
+    echo "Error: Will-retain giving, but no topic given"
+    quit()
+  elif willtopic != "" and willmsg != "":
+    ctx.set_will(willtopic, willmsg, willqos, willretain)
 
   waitFor ctx.connect()
   waitFor ctx.publish(topic, msg, qos, retain)
@@ -26,7 +32,8 @@ Usage:
 OPTIONS
 $options
 """
-  clCfg.hTabCols = @[clOptKeys, clDflVal, clDescrip]
+  #clCfg.hTabCols = @[clOptKeys, clDflVal, clDescrip]
+  clCfg.hTabCols = @[clOptKeys, clDescrip]
   dispatch(nmqttPub,
           doc="Publish MQTT messages to a MQTT-broker.",
           cmdName="nmqtt_pub",
@@ -39,12 +46,20 @@ $options
             "password": "provide a password",
             "topic":    "MQTT topic to publish to.",
             "qos":      "quality of service level to use for all messages.",
-            "retain":   "retain messages on the broker."
+            "retain":   "retain messages on the broker.",
+            "willtopic":"set the will's topic",
+            "willmsg":  "set the will's message",
+            "willqos":  "set the will's quality of service",
+            "willretain":"set to retain the will message"
           },
           short={
             "password": 'P',
             "help": '?',
-            "ssl": '\0'
+            "ssl": '\0',
+            "willtopic": '\0',
+            "willmsg": '\0',
+            "willqos": '\0',
+            "willretain": '\0'
           },
           usage=topLvlUse
           )

--- a/test/tester.nim
+++ b/test/tester.nim
@@ -16,15 +16,16 @@ randomize()
 let ctxMain = newMqttCtx("nmqttTestMain")
 #ctxMain.set_host("test.mosquitto.org", 1883)
 ctxMain.set_host("127.0.0.1", 1883)
-ctxMain.set_ping_interval(120)
+ctxMain.set_ping_interval(1200)
 waitFor ctxMain.start()
 
 # Test clíent slave:
-# ctxSlave is a client which may be closed and open. I should be closed
+# ctxSlave is a client which may be closed and open. It should be closed
 # after each test.
 let ctxSlave = newMqttCtx("nmqttTestSlave")
 #ctxSlave.set_host("test.mosquitto.org", 1883)
 ctxSlave.set_host("127.0.0.1", 1883)
+ctxSlave.set_ping_interval(1200)
 
 # Test clíent listen:
 # ctxListen is a client which only should be used to make subscribe
@@ -32,7 +33,7 @@ ctxSlave.set_host("127.0.0.1", 1883)
 let ctxListen = newMqttCtx("nmqttTestListen")
 #ctxSlave.set_host("test.mosquitto.org", 1883)
 ctxListen.set_host("127.0.0.1", 1883)
-ctxMain.set_ping_interval(120)
+ctxMain.set_ping_interval(1200)
 waitFor ctxListen.start()
 
 proc tout(t, m, s: string) =
@@ -56,9 +57,13 @@ include "publish.nim"
 include "publish_qos.nim"
 include "ping.nim"
 include "utils.nim"
-include "publish_retained.nim" # Retained msg needs to be last test, since it
-                               # will store msg's, which will be caught be subs
-                               # on `#`.
+include "willmsg.nim"          # Contains retained msgs
+include "publish_retained.nim" # Contains retained msgs
+                               #
+                               # When the test contains retained msgs,
+                               # it needs to be the last test, since it
+                               # will store msg's, which will be caught
+                               # in the subscribe test on `#`.
 
 waitFor ctxMain.disconnect()
 waitFor ctxListen.disconnect()

--- a/test/willmsg.nim
+++ b/test/willmsg.nim
@@ -1,0 +1,73 @@
+
+suite "test suite for will messages":
+
+  test "send will msg with default values":
+    let (tpc, msg) = tdata("send will msg with default values")
+
+    proc conn() {.async.} =
+
+      const willMsg = "willmsg_qos0_retain=false"
+      var willMsgCheck: bool
+
+      proc on_data_will(topic: string, message: string) =
+        if topic == tpc and message == willMsg:
+          willMsgCheck = true
+
+      await ctxListen.subscribe(tpc, 2, on_data_will)
+      await sleepAsync 500
+
+      ctxSlave.set_will(tpc, willMsg)
+      await ctxSlave.connect()
+      await sleepAsync 500 # Wait for full connection
+      ctxSlave.s.close()
+      await sleepAsync 500 # Wait for willMsg to be sent
+      check(willMsgCheck == true)
+      ctxSlave.willFlag = true
+
+    waitFor conn()
+
+
+  test "send will msg retained = true":
+    let (tpc, msg) = tdata("send will msg retained = true")
+
+    proc conn() {.async.} =
+
+      const willMsg = "willmsg_qos0_retain=true"
+      var
+        willMsgCheck: bool
+        willMsgRetain: bool
+
+      proc on_data_will(topic: string, message: string) =
+        if topic == tpc and message == willMsg:
+          willMsgCheck = true
+
+      await ctxListen.subscribe(tpc, 2, on_data_will)
+      await sleepAsync 500
+
+      # Set will and send
+      ctxSlave.set_will(tpc, willMsg, retain=true)
+      await ctxSlave.connect()
+      await sleepAsync 500 # Wait for full connection
+      ctxSlave.s.close()
+      await sleepAsync 500 # Wait for willMsg to be sent
+      check(willMsgCheck == true)
+
+      # Check that the message is retained.
+      # New client but on same topic.
+      let ctxDestroy = newMqttCtx("nmqttTestWill")
+      ctxDestroy.set_host("127.0.0.1", 1883)
+      await ctxDestroy.connect()
+
+      proc on_data_will_retain(topic: string, message: string) =
+        if topic == tpc and message == willMsg:
+          willMsgRetain = true
+
+      await ctxDestroy.subscribe(tpc, 2, on_data_will_retain)
+      await sleepAsync 500
+      check(willMsgRetain == true)
+      await ctxDestroy.unsubscribe(tpc)
+      await ctxDestroy.disconnect()
+      ctxDestroy.willFlag = true
+      await sleepAsync 500
+
+    waitFor conn()


### PR DESCRIPTION
This PR implements the clients `will` in the `Connect`-packet.

The user can now specify the `will` with:
```nim
proc set_will*(ctx: MqttCtx, topic, msg: string, qos=0, retain=false) =
  ## Set the clients will.
  ctx.willFlag   = true
  ctx.willTopic  = topic
  ctx.willMsg    = msg
  ctx.willQoS    = qos
  ctx.willRetain = retain
```

**Updated**
* `nmqtt_pub`

* `nmqtt_sub`

* `ctx.set_will`

* `README`

* `test/willmsg.nim`