### PR TITLE
Add the ability to specific SSL cert and key files for library

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ ____
 ### set_ssl_certificates*
 
 ```nim
-proc set_ping_interval*(ctx: MqttCtx, sslCertFile: string, sslKeyFile: string) =
+proc set_ssl_certificates*(ctx: MqttCtx, sslCert: string, sslKey: string) =
 ```
 
 Sets the SSL Certificate and Key files to use Mutual TLS authentication

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ let ctx = newMqttCtx("nmqttClient")
 ctx.set_host("test.mosquitto.org", 1883)
 #ctx.set_auth("username", "password")
 #ctx.set_ping_interval(30)
+#ctx.set_ssl_certificates("cert.crt", "private.key")
 
 proc mqttSub() {.async.} =
   await ctx.start()
@@ -247,6 +248,15 @@ proc set_ping_interval*(ctx: MqttCtx, txInterval: int) =
 
 Set the clients ping interval in seconds. Default is 60 seconds.
 
+____
+
+### set_ssl_certificates*
+
+```nim
+proc set_ping_interval*(ctx: MqttCtx, sslCertFile: string, sslKeyFile: string) =
+```
+
+Sets the SSL Certificate and Key files to use Mutual TLS authentication
 
 ____
 

--- a/nmqtt.nim
+++ b/nmqtt.nim
@@ -1046,6 +1046,7 @@ proc connectBroker(ctx: MqttCtx) {.async.} =
   try:
     ctx.s = await asyncnet.dial(ctx.host, ctx.port)
     if ctx.sslOn:
+      ctx.dbg "Using SSL"
       when defined(ssl):
         ctx.ssl = newContext(protSSLv23, CVerifyNone, ctx.sslCertFile, ctx.sslKeyFile)
         wrapConnectedSocket(ctx.ssl, ctx.s, handshakeAsClient)
@@ -1103,6 +1104,7 @@ proc set_host*(ctx: MqttCtx, host: string, port: int=1883, sslOn=false) =
   ## Set the MQTT host
   ctx.host = host
   ctx.port = Port(port)
+  ctx.sslOn = sslOn
 
 proc set_ssl_certificates*(ctx: MqttCtx, sslCertFile: string, sslKeyFile: string) =
   ctx.sslCertFile = sslCertFile

--- a/nmqtt.nim
+++ b/nmqtt.nim
@@ -25,6 +25,8 @@ type
     host: string
     port: Port
     sslOn: bool
+    sslCertFile: string
+    sslKeyFile: string
     verbosity: int
     beenConnected: bool
     username: string
@@ -1045,7 +1047,7 @@ proc connectBroker(ctx: MqttCtx) {.async.} =
     ctx.s = await asyncnet.dial(ctx.host, ctx.port)
     if ctx.sslOn:
       when defined(ssl):
-        ctx.ssl = newContext(protSSLv23, CVerifyNone)
+        ctx.ssl = newContext(protSSLv23, CVerifyNone, ctx.sslCertFile, ctx.sslKeyFile)
         wrapConnectedSocket(ctx.ssl, ctx.s, handshakeAsClient)
       else:
         ctx.wrn "Requested SSL session but ssl is not enabled"
@@ -1101,7 +1103,10 @@ proc set_host*(ctx: MqttCtx, host: string, port: int=1883, sslOn=false) =
   ## Set the MQTT host
   ctx.host = host
   ctx.port = Port(port)
-  ctx.sslOn = sslOn
+
+proc set_ssl_certificates*(ctx: MqttCtx, sslCertFile: string, sslKeyFile: string) =
+  ctx.sslCertFile = sslCertFile
+  ctx.sslKeyFile = sslKeyFile
 
 proc set_auth*(ctx: MqttCtx, username: string, password: string) =
   ## Set the authentication for the host.

--- a/nmqtt.nim
+++ b/nmqtt.nim
@@ -1046,7 +1046,6 @@ proc connectBroker(ctx: MqttCtx) {.async.} =
   try:
     ctx.s = await asyncnet.dial(ctx.host, ctx.port)
     if ctx.sslOn:
-      ctx.dbg "Using SSL"
       when defined(ssl):
         ctx.ssl = newContext(protSSLv23, CVerifyNone, ctx.sslCertFile, ctx.sslKeyFile)
         wrapConnectedSocket(ctx.ssl, ctx.s, handshakeAsClient)

--- a/nmqtt.nim
+++ b/nmqtt.nim
@@ -25,8 +25,8 @@ type
     host: string
     port: Port
     sslOn: bool
-    sslCertFile: string
-    sslKeyFile: string
+    sslCert: string
+    sslKey: string
     verbosity: int
     beenConnected: bool
     username: string
@@ -1047,7 +1047,7 @@ proc connectBroker(ctx: MqttCtx) {.async.} =
     ctx.s = await asyncnet.dial(ctx.host, ctx.port)
     if ctx.sslOn:
       when defined(ssl):
-        ctx.ssl = newContext(protSSLv23, CVerifyNone, ctx.sslCertFile, ctx.sslKeyFile)
+        ctx.ssl = newContext(protSSLv23, CVerifyNone, ctx.sslCert, ctx.sslKey)
         wrapConnectedSocket(ctx.ssl, ctx.s, handshakeAsClient)
       else:
         ctx.wrn "Requested SSL session but ssl is not enabled"
@@ -1105,9 +1105,11 @@ proc set_host*(ctx: MqttCtx, host: string, port: int=1883, sslOn=false) =
   ctx.port = Port(port)
   ctx.sslOn = sslOn
 
-proc set_ssl_certificates*(ctx: MqttCtx, sslCertFile: string, sslKeyFile: string) =
-  ctx.sslCertFile = sslCertFile
-  ctx.sslKeyFile = sslKeyFile
+proc set_ssl_certificates*(ctx: MqttCtx, sslCert: string, sslKey: string) =
+  # Sets the SSL Certificate and Key to use when connecting to the remote broker
+  # for mutal TLS authentication
+  ctx.sslCert = sslCert
+  ctx.sslKey = sslKey
 
 proc set_auth*(ctx: MqttCtx, username: string, password: string) =
   ## Set the authentication for the host.


### PR DESCRIPTION
I needed to be able to preform Mutual TLS auth with a broker and the library didn't provide a way to set a ssl cert/key during connection so I added it in.

I didn't update the CLI clients since I'm not using them but I can add it in if you would like me to.