### PR TITLE
Add isErrored() function

### DIFF
--- a/nmqtt.nim
+++ b/nmqtt.nim
@@ -1209,6 +1209,11 @@ proc unsubscribe*(ctx: MqttCtx, topic: string): Future[void] =
   ctx.workQueue[msgId] = Work(wk: SubWork, msgId: msgId, topic: topic, typ: Unsubscribe)
   result = ctx.work()
 
+proc isErrored*(ctx: MqttCtx): bool =
+  ## Returns true, if the context is in an error state
+  if ctx.state == Error:
+    result = true
+
 proc isConnected*(ctx: MqttCtx): bool =
   ## Returns true, if the client is connected to the broker.
   if ctx.state == Connected:


### PR DESCRIPTION
Add isErrored() function so we can tell if the context / connection is in the "errored" state, as may occur if the initial TCP connection fails.

Closes #39 