### PR TITLE
Add isErrored() function

### DIFF
--- a/nmqtt.nim
+++ b/nmqtt.nim
@@ -1216,6 +1216,11 @@ proc unsubscribe*(ctx: MqttCtx, topic: string): Future[void] =
   ctx.workQueue[msgId] = Work(wk: SubWork, msgId: msgId, topic: topic, typ: Unsubscribe)
   result = ctx.work()
 
+proc isErrored*(ctx: MqttCtx): bool =
+  ## Returns true, if the context is in an error state
+  if ctx.state == Error:
+    result = true
+
 proc isConnected*(ctx: MqttCtx): bool =
   ## Returns true, if the client is connected to the broker.
   if ctx.state == Connected:


### PR DESCRIPTION
Add isErrored() function so we can tell if the context / connection is in the "errored" state, as may occur if the initial TCP connection fails.

(This commit has been sitting in my fork for 18 months, not sure why I never turned it into a PR before - doing it now in preparation for tidying up my repo list as I move slowly to codeberg. I can't actually remember why I needed this, but I'm pretty sure I did - if you'd like me to go digging for the calling code I used it in to demonstrate the requirement, let me know!)