### PR TITLE
Fix the order of messages in the publishing queue

### DIFF
--- a/nmqtt.nim
+++ b/nmqtt.nim
@@ -36,7 +36,7 @@ type
     s: AsyncSocket
     ssl: SslContext
     msgIdSeq: MsgId
-    workQueue: Table[MsgId, Work]
+    workQueue: OrderedTable[MsgId, Work]
     pubCallbacks: Table[string, PubCallback]
     inWork: bool
     keepAlive: uint16


### PR DESCRIPTION
Due to the use of not ordered table, messages are not sent ordered.

Example:
```nim
import asyncdispatch
import nmqtt

let ctx = newMqttCtx("test")
ctx.setHost("localhost", 1883)

waitFor ctx.start()

waitFor ctx.publish("test/1", "test1", 0, true)
waitFor ctx.publish("test/2", "test2", 0, true)
waitFor ctx.publish("test/3", "test3", 0, true)
waitFor ctx.publish("test/4", "test4", 0, true)
waitFor ctx.publish("test/5", "test5", 0, true)
waitFor ctx.publish("test/6", "test6", 0, true)
waitFor ctx.publish("test/7", "test7", 0, true)
waitFor ctx.publish("test/8", "test8", 0, true)
waitFor ctx.publish("test/9", "test9", 0, true)

runForever()
```

Result with legacy code (`workQueue: Table[MsgId, Work]`):

```
test/4 test4
test/9 test9
test/5 test5
test/7 test7
test/3 test3
test/2 test2
test/6 test6
test/8 test8
test/1 test1
```
Result after changing the code (`workQueue: OrderedTable[MsgId, Work]`):

```
test/1 test1
test/2 test2
test/3 test3
test/4 test4
test/5 test5
test/6 test6
test/7 test7
test/8 test8
test/9 test9
```