### PR TITLE
add ACL support, fix wildcard routing and QoS >0 crash

### DIFF
--- a/config/nmqtt.conf
+++ b/config/nmqtt.conf
@@ -86,6 +86,23 @@ allow_anonymous = true
 #password_file =
 
 #
+# The absolute path to the ACL (Access Control List) file. This uses
+# Mosquitto-compatible ACL format to restrict which users can publish
+# and subscribe to which topics.
+#
+# The ACL file supports:
+#   user <username>         - Start a user-specific rule section
+#   topic [read|write|readwrite] <topic>  - Allow access to a topic
+#   pattern [read|write|readwrite] <topic> - Pattern rules for all users
+#
+# Pattern topics support %u (username) and %c (client ID) substitution.
+# MQTT wildcards (# and +) are supported in topic filters.
+#
+# If no ACL file is specified, all authenticated users have full access.
+#
+#acl_file =
+
+#
 # To activate a SSL connection you need a certificate and a private key.
 # When you specify both of them, the connection will automatic be using
 # SSL. It is common practice to change the port you a listening on from

--- a/nmqtt.nim
+++ b/nmqtt.nim
@@ -16,7 +16,9 @@ when defined(broker):
     times,
     random,
     nmqtt/utils/passwords,
-    nmqtt/utils/version
+    nmqtt/utils/version,
+    nmqtt/utils/acl,
+    nmqtt/utils/trie
   from parsecfg import loadConfig, getSectionValue
   from os import fileExists
 
@@ -142,6 +144,7 @@ when defined(broker):
       connections: Table[string, MqttCtx]
       retained: Table[string, RetainedMsg] # Topic, RetaindMsg
       subscribers: Table[string, seq[MqttCtx]]
+      subTrie: TopicTrie  # Trie index for O(depth) subscription matching
       version: uint8
       clientIdMaxLen: int
       clientKickOld: bool
@@ -150,6 +153,7 @@ when defined(broker):
       passClientId: bool
       maxConnections: int
       passwords: Table[string, string]
+      acl: AclStore
 
     RetainedMsg = object
       msg: string
@@ -159,7 +163,7 @@ when defined(broker):
 
 when defined(broker):
   var
-    mqttbroker = MqttBroker()
+    mqttbroker = MqttBroker(acl: newAclStore(), subTrie: newTopicTrie())
     r = initRand(toInt(epochTime()))
 
 
@@ -289,6 +293,8 @@ when defined(broker):
         mqttbroker.subscribers[topic].insert(ctx)
       else:
         mqttbroker.subscribers[topic] = @[ctx]
+        # First subscriber on this filter, add to the trie index
+        mqttbroker.subTrie.subscribe(topic)
     except:
       wrn("Crash when adding a new subcriber")
 
@@ -298,6 +304,9 @@ when defined(broker):
     try:
       if mqttbroker.subscribers.hasKey(topic):
         mqttbroker.subscribers[topic] = filter(mqttbroker.subscribers[topic], proc(x: MqttCtx): bool = x != ctx)
+        if mqttbroker.subscribers[topic].len() == 0:
+          mqttbroker.subscribers.del(topic)
+          mqttbroker.subTrie.unsubscribe(topic)
     except:
       wrn("Crash when removing subscriber with specific topic")
 
@@ -314,6 +323,7 @@ when defined(broker):
 
     for t in delTop:
       mqttbroker.subscribers.del(t)
+      mqttbroker.subTrie.unsubscribe(t)
 
 when defined(broker):
   proc qosAlign(qP, qS: uint8): uint8 =
@@ -641,20 +651,22 @@ when defined(broker):
         await c.work()
 
 when defined(broker):
-  proc publishToSubscribers(seqctx: seq[MqttCtx], pkt: Pkt, topic, message: string, qos: uint8, retain: bool, senderId: string) {.async.} =
-    ## Publish async to clients
+  proc publishToSubscribers(seqctx: seq[MqttCtx], pkt: Pkt, subFilter, pubTopic, message: string, qos: uint8, retain: bool, senderId: string) {.async.} =
+    ## Publish async to clients.
+    ## `subFilter` is the subscription key (e.g. "topic/subtopic/#") for QoS lookup.
+    ## `pubTopic` is the actual published topic (e.g. "topic/subtopic/specific") sent to the client.
     for c in seqctx:
       if c.state != Connected:
-        asyncCheck removeSubscriber(c, topic)
+        asyncCheck removeSubscriber(c, subFilter)
         continue
       let
         msgId = c.nextMsgId()
-        qosSub = qosAlign(qos, c.subscribed[topic])
+        qosSub = qosAlign(qos, c.subscribed[subFilter])
 
       if mqttbroker.passClientId:
-        c.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, topic: topic, qos: qosSub, retain: retain, message: senderId & ":" & message, typ: Publish)
+        c.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, topic: pubTopic, qos: qosSub, retain: retain, message: senderId & ":" & message, typ: Publish)
       else:
-        c.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, topic: topic, qos: qosSub, retain: retain, message: message, typ: Publish)
+        c.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, topic: pubTopic, qos: qosSub, retain: retain, message: message, typ: Publish)
       await c.work()
 
 when defined(broker):
@@ -810,12 +822,25 @@ proc onPublish(ctx: MqttCtx, pkt: Pkt) {.async.} =
   (message, offset) = pkt.getstring(offset, false)
 
   when defined(broker):
-    # Send message to all subscribers on "#"
-    if mqttbroker.subscribers.hasKey("#"):
-      await publishToSubscribers(mqttbroker.subscribers["#"], pkt, "#", message, qos, retain, ctx.clientid)
-    # Send message to all subscribers on _the topic_
-    if mqttbroker.subscribers.hasKey(topic):
-      await publishToSubscribers(mqttbroker.subscribers[topic], pkt, topic, message, qos, retain, ctx.clientid)
+    # Check ACL: does the publishing client have write access?
+    if not mqttbroker.acl.checkPublish(ctx.username, ctx.clientId, topic):
+      if mqttbroker.verbosity >= 1:
+        verbose("ACL         >> " & ctx.clientId & " denied publish to " & topic)
+      # Per MQTT v3.1.1, the broker silently drops the message but still
+      # completes the QoS handshake so the client doesn't stall.
+      if qos == 1:
+        ctx.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, state: WorkNew, qos: 1, typ: PubAck)
+        await ctx.work()
+      elif qos == 2:
+        ctx.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, state: WorkNew, qos: 2, typ: PubRec)
+        await ctx.work()
+      return
+
+    # Route the published message to all matching subscribers.
+    # Uses the trie index for O(topic_depth) matching instead of O(n) scan.
+    for subFilter in mqttbroker.subTrie.matchingFilters(topic):
+      if mqttbroker.subscribers.hasKey(subFilter):
+        await publishToSubscribers(mqttbroker.subscribers[subFilter], pkt, subFilter, topic, message, qos, retain, ctx.clientid)
 
     if mqttbroker.verbosity >= 1:
       verbose("Client      >> " & ctx.clientId & " has published a message")
@@ -869,36 +894,44 @@ proc onPublish(ctx: MqttCtx, pkt: Pkt) {.async.} =
 
 proc onPubAck(ctx: MqttCtx, pkt: Pkt) {.async.} =
   let (msgId, _) = pkt.getu16(0)
-  assert msgId in ctx.workQueue
-  assert ctx.workQueue[msgId].wk == PubWork
-  assert ctx.workQueue[msgId].state == WorkSent
-  assert ctx.workQueue[msgId].qos == 1
+  if msgId notin ctx.workQueue:
+    ctx.dmp "PubAck for unknown msgId: " & $msgId
+    return
+  if ctx.workQueue[msgId].wk != PubWork or ctx.workQueue[msgId].qos != 1:
+    ctx.dmp "PubAck unexpected state for msgId: " & $msgId
+    return
   ctx.workQueue.del msgId
 
 proc onPubRec(ctx: MqttCtx, pkt: Pkt) {.async.} =
   let (msgId, _) = pkt.getu16(0)
-  assert msgId in ctx.workQueue
-  assert ctx.workQueue[msgId].wk == PubWork
-  assert ctx.workQueue[msgId].state == WorkSent
-  assert ctx.workQueue[msgId].qos == 2
+  if msgId notin ctx.workQueue:
+    ctx.dmp "PubRec for unknown msgId: " & $msgId
+    return
+  if ctx.workQueue[msgId].wk != PubWork or ctx.workQueue[msgId].qos != 2:
+    ctx.dmp "PubRec unexpected state for msgId: " & $msgId
+    return
   ctx.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, state: WorkNew, qos: 2, typ: PubRel)
   await ctx.work()
 
 proc onPubRel(ctx: MqttCtx, pkt: Pkt) {.async.} =
   let (msgId, _) = pkt.getu16(0)
-  assert msgId in ctx.workQueue
-  assert ctx.workQueue[msgId].wk == PubWork
-  assert ctx.workQueue[msgId].state == WorkSent
-  assert ctx.workQueue[msgId].qos == 2
+  if msgId notin ctx.workQueue:
+    ctx.dmp "PubRel for unknown msgId: " & $msgId
+    return
+  if ctx.workQueue[msgId].wk != PubWork or ctx.workQueue[msgId].qos != 2:
+    ctx.dmp "PubRel unexpected state for msgId: " & $msgId
+    return
   ctx.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, state: WorkNew, qos: 2, typ: PubComp)
   await ctx.work()
 
 proc onPubComp(ctx: MqttCtx, pkt: Pkt) {.async.} =
   let (msgId, _) = pkt.getu16(0)
-  assert msgId in ctx.workQueue
-  assert ctx.workQueue[msgId].wk == PubWork
-  assert ctx.workQueue[msgId].state == WorkSent
-  assert ctx.workQueue[msgId].qos == 2
+  if msgId notin ctx.workQueue:
+    ctx.dmp "PubComp for unknown msgId: " & $msgId
+    return
+  if ctx.workQueue[msgId].wk != PubWork or ctx.workQueue[msgId].qos != 2:
+    ctx.dmp "PubComp unexpected state for msgId: " & $msgId
+    return
   ctx.workQueue.del msgId
 
 #when defined(broker):
@@ -920,6 +953,15 @@ proc onSubscribe(ctx: MqttCtx, pkt: Pkt) {.async.} =
       (nextLen, offset) = pkt.getu16(offset)
       (topic, offset)   = pkt.getstring(offset, parseInt($nextLen))
       (qos, offset)     = pkt.getu8(offset)
+
+      # Check ACL: does the client have read access for this topic?
+      if not mqttbroker.acl.checkSubscribe(ctx.username, ctx.clientId, topic):
+        if mqttbroker.verbosity >= 1:
+          verbose("ACL         >> " & ctx.clientId & " denied subscribe to " & topic)
+        # Send SubAck with failure return code (0x80) per MQTT v3.1.1 spec
+        ctx.workQueue[msgId] = Work(wk: PubWork, msgId: msgId, state: WorkNew, qos: 0, typ: SubAck)
+        await ctx.work()
+        return
 
       ctx.subscribed[topic] = qos
       await addSubscriber(ctx, topic)

--- a/nmqtt/nmqtt.nim
+++ b/nmqtt/nmqtt.nim
@@ -132,10 +132,12 @@ OPTIONS:
   ClientID in payload:   $11
   Client kick old:       $12
   Number of passwords:   $13
+  ACL loaded:            $14
 
   """.format(nmqttVersion, mb.host, mb.port, mb.sslOn, now(), mb.verbosity,
               mb.maxConnections, mb.clientIdMaxLen, mb.spacesInClientId,
-              mb.emptyClientId, mb.passClientId, mb.clientKickOld, mb.passwords.len()
+              mb.emptyClientId, mb.passClientId, mb.clientKickOld, mb.passwords.len(),
+              mb.acl.loaded
             )
 
 
@@ -194,6 +196,16 @@ proc loadConf(mb: MqttBroker, config: string) =
     let passwordFile = dict.getSectionValue("","password_file")
     loadPasswords(passwordFile)
 
+  # Load ACL file if specified
+  let aclFile = dict.getSectionValue("","acl_file")
+  if aclFile != "":
+    if not fileExists(aclFile):
+      echo "\nACL file does not exist..\n - " & aclFile
+      quit()
+    mqttbroker.acl.loadAclFile(aclFile)
+    if mqttbroker.verbosity >= 1:
+      echo "ACL loaded from: " & aclFile
+
 
 proc handler() {.noconv.} =
   ## Catch ctrl+c from user
@@ -206,6 +218,7 @@ proc handler() {.noconv.} =
 proc nmqttBroker(config="", host="127.0.0.1", port=1883, verbosity=0, max_conn=0,
                   clientid_maxlen=60, clientid_spaces=false, clientid_empty=false,
                   client_kickold=false, clientid_pass=false, password_file="",
+                  acl_file="",
                   ssl=false, ssl_cert="", ssl_key=""
                 ) {.async.} =
   ## CLI tool for a MQTT broker
@@ -225,6 +238,12 @@ proc nmqttBroker(config="", host="127.0.0.1", port=1883, verbosity=0, max_conn=0
 
     if password_file != "":
       loadPasswords(password_file)
+
+    if acl_file != "":
+      if not fileExists(acl_file):
+        echo "\nACL file does not exist..\n - " & acl_file
+        quit()
+      mqttbroker.acl.loadAclFile(acl_file)
 
     if ssl:
       mqttbroker.sslOn   = true
@@ -282,6 +301,7 @@ $options
             "client-kickold":   "kick old client, if new client has same clientid. Defaults to false.",
             "clientid-pass":    "pass clientid in payload {clientid:payload}. Defaults to false.",
             "password-file":    "absolute path to the password file",
+            "acl-file":         "absolute path to the ACL file (Mosquitto-compatible format)",
             "ssl":              "activate ssl for the broker - requires --ssl-cert and --ssl-key.",
             "ssl-cert":         "absolute path to the ssl certificate.",
             "ssl-key":          "absolute path to the ssl key."
@@ -289,6 +309,7 @@ $options
           short={
             "help": '?',
             "max-conn": '\0',
+            "acl-file": '\0',
             "ssl": '\0',
             "ssl-cert": '\0',
             "ssl-key": '\0'

--- a/nmqtt/utils/acl.nim
+++ b/nmqtt/utils/acl.nim
@@ -1,0 +1,223 @@
+## Access Control List (ACL) module for nmqtt broker
+##
+## Provides Mosquitto-compatible ACL file parsing and topic access control.
+## Supports user-specific rules and pattern-based rules with %u (username)
+## and %c (client ID) substitution.
+##
+## ACL file format:
+##   # Comments start with #
+##   user <username>
+##   topic [read|write|readwrite] <topic>
+##
+##   pattern [read|write|readwrite] <topic>
+##
+## The `user` directive starts a user-specific section. All `topic` directives
+## that follow apply to that user until the next `user` directive.
+##
+## The `pattern` directive defines rules that apply to all authenticated users.
+## Patterns support %u (replaced with username) and %c (replaced with client ID).
+##
+## Topic wildcards:
+##   # - multi-level wildcard (matches any number of levels)
+##   + - single-level wildcard (matches exactly one level)
+
+import strutils, tables
+
+type
+  AclAccess* = enum
+    AclRead = "read"
+    AclWrite = "write"
+    AclReadWrite = "readwrite"
+
+  AclRule* = object
+    topic*: string
+    access*: AclAccess
+
+  AclStore* = ref object
+    ## Holds all parsed ACL rules
+    userRules*: Table[string, seq[AclRule]]   ## Per-user rules (keyed by username)
+    patternRules*: seq[AclRule]               ## Pattern rules (apply to all users)
+    loaded*: bool                             ## Whether an ACL file has been loaded
+
+
+proc newAclStore*(): AclStore =
+  AclStore(
+    userRules: initTable[string, seq[AclRule]](),
+    patternRules: @[],
+    loaded: false
+  )
+
+
+proc parseAccess(token: string): AclAccess =
+  ## Parse an access keyword. Defaults to readwrite if not specified.
+  case token.toLowerAscii()
+  of "read": AclRead
+  of "write": AclWrite
+  of "readwrite": AclReadWrite
+  else: AclReadWrite
+
+
+proc loadAclFile*(store: AclStore, filename: string) =
+  ## Parse a Mosquitto-compatible ACL file and populate the store.
+  var currentUser = ""
+
+  for rawLine in readFile(filename).splitLines():
+    let line = rawLine.strip()
+
+    # Skip empty lines and comments
+    if line.len == 0 or line[0] == '#':
+      continue
+
+    let parts = line.splitWhitespace()
+    if parts.len == 0:
+      continue
+
+    case parts[0].toLowerAscii()
+    of "user":
+      # Start a new user section
+      if parts.len >= 2:
+        currentUser = parts[1]
+        if not store.userRules.hasKey(currentUser):
+          store.userRules[currentUser] = @[]
+
+    of "topic":
+      # Topic rule under a user section
+      var access: AclAccess
+      var topic: string
+
+      if parts.len == 3:
+        # topic <access> <topic>
+        access = parseAccess(parts[1])
+        topic = parts[2]
+      elif parts.len == 2:
+        # topic <topic> (defaults to readwrite)
+        access = AclReadWrite
+        topic = parts[1]
+      else:
+        continue
+
+      let rule = AclRule(topic: topic, access: access)
+
+      if currentUser != "":
+        store.userRules[currentUser].add(rule)
+      # If no user section is active, ignore the topic line per Mosquitto behavior
+
+    of "pattern":
+      # Pattern rule (applies to all authenticated users)
+      var access: AclAccess
+      var topic: string
+
+      if parts.len == 3:
+        access = parseAccess(parts[1])
+        topic = parts[2]
+      elif parts.len == 2:
+        access = AclReadWrite
+        topic = parts[1]
+      else:
+        continue
+
+      store.patternRules.add(AclRule(topic: topic, access: access))
+
+    else:
+      discard
+
+  store.loaded = true
+
+
+proc topicMatchesFilter*(topic, filter: string): bool =
+  ## Check if a concrete topic matches a filter pattern with MQTT wildcards.
+  ## Supports # (multi-level) and + (single-level) wildcards.
+  if filter == "#":
+    return true
+
+  let topicParts = topic.split('/')
+  let filterParts = filter.split('/')
+
+  var ti = 0
+  var fi = 0
+
+  while fi < filterParts.len:
+    if filterParts[fi] == "#":
+      # # matches everything from here on, including zero levels
+      return true
+
+    if ti >= topicParts.len:
+      # Topic is shorter than filter, no match
+      return false
+
+    if filterParts[fi] == "+":
+      # + matches exactly one level
+      ti += 1
+      fi += 1
+      continue
+
+    if filterParts[fi] != topicParts[ti]:
+      return false
+
+    ti += 1
+    fi += 1
+
+  # Both must be fully consumed for a match (unless filter ended with #)
+  return ti == topicParts.len and fi == filterParts.len
+
+
+proc substitutePattern(pattern, username, clientid: string): string =
+  ## Replace %u with username and %c with client ID in a pattern topic.
+  result = pattern
+  result = result.replace("%u", username)
+  result = result.replace("%c", clientid)
+
+
+proc checkAccess*(store: AclStore, username, clientid, topic: string,
+                  wantWrite: bool): bool =
+  ## Check whether a user is allowed to access a topic.
+  ##
+  ## If no ACL file is loaded, all access is allowed (open broker).
+  ## If an ACL file is loaded, access is denied by default unless a
+  ## matching rule grants it.
+  ##
+  ## `wantWrite` = true for publish, false for subscribe.
+
+  if not store.loaded:
+    return true  # No ACL loaded, allow everything
+
+  # Check user-specific rules
+  if store.userRules.hasKey(username):
+    for rule in store.userRules[username]:
+      if topicMatchesFilter(topic, rule.topic):
+        case rule.access
+        of AclReadWrite:
+          return true
+        of AclRead:
+          if not wantWrite:
+            return true
+        of AclWrite:
+          if wantWrite:
+            return true
+
+  # Check pattern rules (apply to all authenticated users)
+  for rule in store.patternRules:
+    let expandedTopic = substitutePattern(rule.topic, username, clientid)
+    if topicMatchesFilter(topic, expandedTopic):
+      case rule.access
+      of AclReadWrite:
+        return true
+      of AclRead:
+        if not wantWrite:
+          return true
+      of AclWrite:
+        if wantWrite:
+          return true
+
+  # Default deny when ACL is loaded
+  return false
+
+
+proc checkPublish*(store: AclStore, username, clientid, topic: string): bool =
+  ## check if a user can publish (write) to a topic.
+  store.checkAccess(username, clientid, topic, wantWrite = true)
+
+
+proc checkSubscribe*(store: AclStore, username, clientid, topic: string): bool =
+  ## check if a user can subscribe (read) to a topic.
+  store.checkAccess(username, clientid, topic, wantWrite = false)

--- a/nmqtt/utils/trie.nim
+++ b/nmqtt/utils/trie.nim
@@ -1,0 +1,86 @@
+## Provides O(topic_depth) lookup for matching a published topic against all
+## subscription filters, instead of O(n) linear scan over all subscriptions.
+##
+## The trie is keyed on `/`-delimited topic segments. Wildcard nodes (`+` and
+## `#`) are stored as children alongside literal segments. On lookup, the trie
+## walks all branches that could match, including wildcard branches.
+
+import tables, strutils
+
+type
+  TrieNode* = ref object
+    children: Table[string, TrieNode]
+    ## Subscription filters that terminate at this node, stored as the
+    ## full original filter string. A seq because multiple clients may
+    ## subscribe with different filters that resolve to the same trie path
+    filters: seq[string]
+
+  TopicTrie* = ref object
+    root*: TrieNode
+
+
+proc newTopicTrie*(): TopicTrie =
+  TopicTrie(root: TrieNode())
+
+
+proc subscribe*(trie: TopicTrie, filter: string) =
+  ## Insert a subscription filter into the trie.
+  var node = trie.root
+  for segment in filter.split('/'):
+    if not node.children.hasKey(segment):
+      node.children[segment] = TrieNode()
+    node = node.children[segment]
+  if filter notin node.filters:
+    node.filters.add(filter)
+
+
+proc unsubscribe*(trie: TopicTrie, filter: string) =
+  ## Remove a subscription filter from the trie.
+  ## Does not prune empty nodes
+  var node = trie.root
+  for segment in filter.split('/'):
+    if not node.children.hasKey(segment):
+      return  # Filter wasn't in trie
+    node = node.children[segment]
+  let idx = node.filters.find(filter)
+  if idx >= 0:
+    node.filters.del(idx)
+
+
+proc matchingFilters*(trie: TopicTrie, topic: string): seq[string] =
+  ## Return all subscription filters that match the given concrete topic.
+  ## Handles `+` (single-level) and `#` (multi-level) wildcards.
+  ##
+  ## This is the hot path, called once per published message.
+  let segments = topic.split('/')
+
+  # Stack-based DFS. Each entry is (node, segment_index).
+  var stack: seq[(TrieNode, int)]
+  stack.add((trie.root, 0))
+
+  while stack.len > 0:
+    let (node, depth) = stack.pop()
+
+    # `#` wildcard: matches everything from this level onward, including
+    # zero or more additional levels. If a `#` child exists at any depth,
+    # all its filters match.
+    if node.children.hasKey("#"):
+      let hashNode = node.children["#"]
+      for f in hashNode.filters:
+        result.add(f)
+
+    # If we've consumed all segments, check for filters at this node
+    if depth == segments.len:
+      for f in node.filters:
+        result.add(f)
+      continue
+
+    let segment = segments[depth]
+
+    # Exact match on this segment
+    if node.children.hasKey(segment):
+      stack.add((node.children[segment], depth + 1))
+
+    # `+` wildcard: matches exactly one level (any segment)
+    if node.children.hasKey("+"):
+      stack.add((node.children["+"], depth + 1))


### PR DESCRIPTION
This change adds Mosquitto compatible ACL file support (user/topic rules, pattern rules with %u/%c substitution).

Replaces broken topic routing with trie-based index. The broker previously only matched the literal "#" and exact topic string, so subscribers on filters like foo/# or foo/+/bar never received messages. The trie resolves matches in O(topic depth) instead of O(subscription count).

Replaces assert statements in onPubAck, onPubRec, onPubRel, and onPubComp with graceful checks. The asserts crash the broker under normal QoS > 0 operation when work queue state doesn't match expectations due to timing or msgId reuse.

<img width="1366" height="768" alt="2026-02-12-233438_1366x768_scrot" src="https://github.com/user-attachments/assets/0f1e5b52-f451-4c6c-9c81-b6889b5b11d8" />

For color/context, I'm working on building a [SaltStack like configuration management tool](https://krei.lambdacreate.com/durrendal/scio) with nmqtt as the MQTT broker/client in that stack. Adding ACL handling and trie topic parsing will allow me to replace Mosquitto in that setup with a custom nmqtt based broker.

Tangentially, I've also [ported nmqtt and its build deps](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/93001) to Alpine Linux as part of that same effort.