### PR TITLE
Ensure only one active ping worker per connection

### DIFF
--- a/nmqtt.nim
+++ b/nmqtt.nim
@@ -40,6 +40,7 @@ type
     pubCallbacks: Table[string, PubCallback]
     inWork: bool
     keepAlive: uint16
+    pingWorkerId: int
     willFlag: bool
     willQoS: uint8
     willRetain: bool
@@ -1050,9 +1051,11 @@ proc runRx(ctx: MqttCtx) {.async.} =
     if ctx.verbosity >= 2:
       ctx.wrn "Boom, socket is closed"
 
-proc runPing(ctx: MqttCtx) {.async.} =
+proc runPing(ctx: MqttCtx, workerId: int) {.async.} =
   while true:
     await sleepAsync ctx.keepAlive.int * 1000
+    if workerId != ctx.pingWorkerId:
+      break
     let ok = await ctx.sendPingReq()
     if not ok:
       break
@@ -1079,8 +1082,9 @@ proc connectBroker(ctx: MqttCtx) {.async.} =
 
   let ok = await ctx.sendConnect()
   if ok:
+    ctx.pingWorkerId.inc
     asyncCheck ctx.runRx()
-    asyncCheck ctx.runPing()
+    asyncCheck ctx.runPing(ctx.pingWorkerId)
 
 
 proc runConnect(ctx: MqttCtx) {.async.} =


### PR DESCRIPTION
When reconnecting, runPing() is started again while previous ping workers may still be running. Since the worker references `ctx` (and not a specific socket instance), it can continue operating after a reconnect and use the updated socket.

This can result in multiple concurrent ping workers sending PINGREQ frames at the keepAlive interval.

Introduce a simple generation guard (pingWorkerId) that is incremented on each successful connection. Each ping worker stores the generation it was started with and exits if it detects a newer generation.

This guarantees that only one active ping worker exists per connection without introducing additional synchronization primitives or changing public APIs.