### PR TITLE
Fix broken logic when appending in async

### DIFF
--- a/nmqtt.nim
+++ b/nmqtt.nim
@@ -39,6 +39,7 @@ type
     workQueue: OrderedTable[MsgId, Work]
     pubCallbacks: Table[string, PubCallback]
     inWork: bool
+    hasNewWorks: bool
     keepAlive: uint16
     willFlag: bool
     willQoS: uint8
@@ -587,31 +588,32 @@ proc sendWork(ctx: MqttCtx, work: Work): Future[bool] =
     ctx.wrn("Error sending unknown package: " & $work.typ)
 
 proc work(ctx: MqttCtx) {.async.} =
+  ctx.hasNewWorks = true
   if ctx.inWork:
     return
   ctx.inWork = true
-  if ctx.state == Connected:
-    var delWork: seq[MsgId]
-    let workQueue = ctx.workQueue # TODO: We need to copy the workQueue, otherwise
-                                  # we can hit: `the length of the table changed
-                                  # while iterating over it`
+
+  while ctx.state == Connected and ctx.hasNewWorks:
+    ctx.hasNewWorks = false
+    let workQueue = ctx.workQueue
+
     for msgId, work in workQueue:
 
       #when defined(broker):
       if work.typ in [ConnAck, SubAck, UnsubAck, PingResp]:
         if await ctx.sendWork(work):
-          delWork.add msgId
+          ctx.workQueue.del msgId
           continue
 
       if work.wk == PubWork and work.state == WorkNew:
         if work.typ == Publish and work.qos == 0:
-          if await ctx.sendWork(work): delWork.add msgId
+          if await ctx.sendWork(work): ctx.workQueue.del msgId
 
         elif work.typ == PubAck and work.qos == 1:
-          if await ctx.sendWork(work): delWork.add msgId
+          if await ctx.sendWork(work): ctx.workQueue.del msgId
 
         elif work.typ == PubComp and work.qos == 2:
-          if await ctx.sendWork(work): delWork.add msgId
+          if await ctx.sendWork(work): ctx.workQueue.del msgId
 
         else:
           if await ctx.sendWork(work): work.state = WorkSent
@@ -626,8 +628,6 @@ proc work(ctx: MqttCtx) {.async.} =
             work.state = WorkSent
             ctx.pubCallbacks.del work.topic
 
-    for msgId in delWork:
-      ctx.workQueue.del msgId
   ctx.inWork = false
 
 when defined(broker):


### PR DESCRIPTION
Test code:
```nim
import nmqtt
import asyncdispatch

let localCtx = newMqttCtx("test_async")
localCtx.setHost("localhost", 1883)
waitFor localCtx.start()

proc test(ind: string) {.async.} =
  for i in 1..2:
    await localCtx.publish("test/" & ind & "/" & $i, "test", 0, false)
    await sleepAsync 1

proc main() {.async.} =
  asyncCheck test("1")
  asyncCheck test("2")

asyncCheck main()

runForever()
```

Run listener:

```bash
mosquitto_sub -p 1883 -t "test/#" -v
```

Result:

```log
test/1/1 test
test/2/1 test
test/1/2 test
```

**Skipped `test/2/2 test`!**

---

Problem (nmqtt.nim):
Since the table is copied before the loop, if a new Work is added while the loop is being processed, it will be ignored.
```nim
proc work(ctx: MqttCtx) {.async.} =

# ...

    for msgId, work in workQueue:

      #when defined(broker):
      if work.typ in [ConnAck, SubAck, UnsubAck, PingResp]:
        if await ctx.sendWork(work):
          delWork.add msgId
          continue

      if work.wk == PubWork and work.state == WorkNew:
        if work.typ == Publish and work.qos == 0:
          if await ctx.sendWork(work): delWork.add msgId # <--- at this point

        elif work.typ == PubAck and work.qos == 1:
          if await ctx.sendWork(work): delWork.add msgId # <--- at this point

        elif work.typ == PubComp and work.qos == 2:
          if await ctx.sendWork(work): delWork.add msgId # <--- at this point

        else:
          if await ctx.sendWork(work): work.state = WorkSent # <--- at this point

      #when not defined(broker):
      elif work.wk == SubWork and work.state == WorkNew:
        if work.typ == Subscribe:
          if await ctx.sendWork(work): work.state = WorkSent # <--- at this point

        elif work.typ == Unsubscribe:
          if await ctx.sendWork(work): # <--- at this point
            work.state = WorkSent
            ctx.pubCallbacks.del work.topic

# ...
```

---

Solution: After looping through the table, check whether new Works have been added. Result after changes:

```log
test/1/1 test
test/2/1 test
test/1/2 test
test/2/2 test
```

**`test/2/2 test` not skipped!**