### PR TITLE
Implement reliable packet receiving logic

### DIFF
--- a/nmqtt.nim
+++ b/nmqtt.nim
@@ -423,9 +423,18 @@ proc recv(ctx: MqttCtx): Future[Pkt] {.async.} =
 
   if len > 0:
     pkt.data.setlen len
-    r = await ctx.s.recvInto(pkt.data[0].addr, len)
 
-    if r != len:
+    var offset = 0
+    while offset < len:
+      try:
+        r = await ctx.s.recvInto(addr pkt.data[offset], len - offset)
+      except:
+        break
+      if r == 0:
+        break
+      offset += r
+
+    if offset != len:
       when not defined(broker):
         await ctx.close("remote closed connection")
       return


### PR DESCRIPTION
This PR introduces a while loop for recvInto to ensure the exact number of bytes is received. This prevents protocol desynchronization caused by partial reads.


_Credits: This implementation is based on the code from PR #48 by @centurysys, with some slight modifications and refactoring. Huge thanks to him for identifying this critical issue and providing the initial solution!_